### PR TITLE
Verification Flags II

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,10 +13,7 @@
 
 # misc
 .DS_Store
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env.*
 
 npm-debug.log*
 yarn-debug.log*

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,8 @@
   - The data Open Dialog no longer displays 
     + the region constraint, if a dataset has no spatial coordinates;
     + the cached option, if a dataset cannot be cached.
-  - Displaying a data source's data type, if given, in it's list item.
+  - Displaying a data source's data type, if given, in its list item.
+  - Fixed crash on double-clicking a list item with no selection.
 * Using term "sandboxed file system" instead of "user root" in about box.
 
 #### From previous

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,13 +3,17 @@
 #### In current
 
 * The DATA SOURCES panel has been updated:
-  - Fixed deferred effect of checkbox "Show identifiers"
-  - Added checkbox "All data sources" that will display all ODP datasets
+  - Fixed deferred effect of checkbox "Show identifiers".
+  - Added checkbox "All data sources" that will display all ODP datasets.
   - Added warn icon to those datasets that cannot be opened from store.
     Such data sources disable the "Open" button and display a popup 
     instead. The popup informs the user how to manually download and open 
-    the datasets. 
-* Using term "sandboxed file system" instead of "user root" in about box 
+    the datasets.
+  - The data Open Dialog no longer displays 
+    + the region constraint, if a dataset has no spatial coordinates;
+    + the cached option, if a dataset cannot be cached.
+  - Displaying a data source's data type, if given, in it's list item.
+* Using term "sandboxed file system" instead of "user root" in about box.
 
 #### From previous
 

--- a/src/renderer/components/DataSourceItem.tsx
+++ b/src/renderer/components/DataSourceItem.tsx
@@ -11,9 +11,11 @@ import { canOpenDataSource } from '../state-util';
 const ECV_META: EcvMeta = _ecvMeta;
 
 
-const ITEM_DIV_STYLE: CSSProperties = {display: 'flex', alignItems: 'flex-start'};
-const ID_DIV_STYLE: CSSProperties = {color: Colors.GREEN4, fontSize: '0.8em'};
-const TEXT_ICON_DIV_STYLE: CSSProperties = {
+const ITEM_STYLE: CSSProperties = {display: 'flex', alignItems: 'flex-start'};
+const ID_STYLE: CSSProperties = {color: Colors.BLUE5, fontSize: '0.8em'};
+const WARN_ICON_STYLE: CSSProperties = {marginRight: 4};
+const TYPE_SPEC_STYLE: CSSProperties = {color: Colors.GREEN4, fontSize: '0.8em', marginLeft: 4};
+const TEXT_ICON_STYLE: CSSProperties = {
     width: 32,
     height: 32,
     flex: 'none',
@@ -25,7 +27,6 @@ const TEXT_ICON_DIV_STYLE: CSSProperties = {
     justifyContent: 'center',
     alignItems: 'center',
 };
-const WARN_ICON_STYLE: CSSProperties = {marginRight: 4};
 
 interface DataSourceItemProps {
     dataSource: DataSourceState;
@@ -49,7 +50,7 @@ const DataSourceItem: React.FC<DataSourceItemProps> = ({dataSource, showDataSour
     if (!label) {
         label = ecvId.substr(0, 3).toUpperCase() || '?';
     }
-    const icon = <div style={{...TEXT_ICON_DIV_STYLE, backgroundColor}}>{label}</div>;
+    const icon = <div style={{...TEXT_ICON_STYLE, backgroundColor}}>{label}</div>;
 
     const title = dataSource.title || (metaInfo && metaInfo.title);
 
@@ -59,16 +60,21 @@ const DataSourceItem: React.FC<DataSourceItemProps> = ({dataSource, showDataSour
         warnIcon = <Icon icon={"warning-sign"} intent={Intent.WARNING} iconSize={16} style={WARN_ICON_STYLE}/>
     }
 
+    let typeSpec;
+    if (dataSource.typeSpecifier) {
+        typeSpec = <span style={TYPE_SPEC_STYLE}>{dataSource.typeSpecifier}</span>;
+    }
+
     return (
-        <div style={ITEM_DIV_STYLE}>
+        <div style={ITEM_STYLE}>
             {icon}
             {showDataSourceIDs ? (
                 <div>
-                    <div className="user-selectable">{warnIcon}{title}</div>
-                    <div className="user-selectable" style={ID_DIV_STYLE}>{dataSource.id}</div>
+                    <div className="user-selectable">{warnIcon}{title}{typeSpec}</div>
+                    <div className="user-selectable" style={ID_STYLE}>{dataSource.id}</div>
                 </div>
             ) : (
-                 <span className="user-selectable">{warnIcon}{title}</span>
+                 <span className="user-selectable">{warnIcon}{title}{typeSpec}</span>
              )}
         </div>
     );

--- a/src/renderer/containers/DataSourcesPanel.tsx
+++ b/src/renderer/containers/DataSourcesPanel.tsx
@@ -241,7 +241,7 @@ class DataSourcesPanel extends React.Component<IDataSourcesPanelProps & IDataSou
                                                   : null}
                             setSelectedDataSourceId={this.props.setSelectedDataSourceId}
                             showDataSourceIDs={this.props.showDataSourceIDs}
-                            doubleClickAction={this.handleShowOpenDatasetDialog}
+                            doubleClickAction={canOpen ? this.handleShowOpenDatasetDialog : undefined}
                         />)
                      : this.renderNoDataSourcesMessage()
                     }
@@ -260,6 +260,7 @@ class DataSourcesPanel extends React.Component<IDataSourcesPanelProps & IDataSou
     }
 
     private handleShowOpenDatasetDialog() {
+        const canOpen = this.props.selectedDataSource;
         this.maybeLoadTemporalCoverage();
         this.props.showDialog('openDatasetDialog');
     }

--- a/src/renderer/selectors.ts
+++ b/src/renderer/selectors.ts
@@ -2,7 +2,13 @@ import { createSelector, Selector } from 'reselect';
 import * as Cesium from 'cesium';
 
 import { requireElectron } from './electron';
-import { canOpenDataSource, DEFAULT_BASE_MAP, DEFAULT_BASE_MAP_ID } from './state-util';
+import {
+    canCacheDataSource,
+    canMapDataSource,
+    canOpenDataSource,
+    DEFAULT_BASE_MAP,
+    DEFAULT_BASE_MAP_ID
+} from './state-util';
 import {
     BaseMapState,
     ColorMapCategoryState,
@@ -440,6 +446,20 @@ export const selectedDataSourceTemporalCoverageSelector = createSelector<State, 
     selectedDataSourceSelector,
     (selectedDataSource: DataSourceState): [string, string] | null => {
         return selectedDataSource ? selectedDataSource.temporalCoverage : null;
+    }
+);
+
+export const canCacheDataSourceSelector = createSelector<State, boolean, DataSourceState | null>(
+    selectedDataSourceSelector,
+    (selectedDataSource: DataSourceState | null): boolean => {
+        return selectedDataSource ? canCacheDataSource(selectedDataSource) : false;
+    }
+);
+
+export const canMapDataSourceSelector = createSelector<State, boolean, DataSourceState | null>(
+    selectedDataSourceSelector,
+    (selectedDataSource: DataSourceState | null): boolean => {
+        return selectedDataSource ? canMapDataSource(selectedDataSource) : false;
     }
 );
 

--- a/src/renderer/state-util.ts
+++ b/src/renderer/state-util.ts
@@ -109,6 +109,10 @@ export function canCacheDataSource(dataSource: DataSourceState) {
     return _checkDataSource(dataSource, 'cache');
 }
 
+export function canMapDataSource(dataSource: DataSourceState) {
+    return _checkDataSource(dataSource, 'map');
+}
+
 function _checkDataSource(dataSource: DataSourceState, ...flags: DataSourceVerificationFlags[]): boolean {
     if (Array.isArray(dataSource.verificationFlags)) {
         // dataSource.verificationFlags have been introduced for ESA CCI datasets only


### PR DESCRIPTION

  - The data Open Dialog no longer displays 
    + the region constraint, if a dataset has no spatial coordinates;
    + the cached option, if a dataset cannot be cached.
  - Displaying a data source's data type, if given, in its list item.
  - Fixed crash on double-clicking a list item with no selection.
