### PR TITLE
Forman xxx xcube intergr 2

### DIFF
--- a/.env
+++ b/.env
@@ -14,8 +14,8 @@ REACT_APP_KEYCLOAK_CLIENT_ID=cate-webui
 # REACT_APP_MAX_NUM_USERS=50
 
 # TODO: document me
-# REACT_APP_CATEHUB_ENDPOINT=https://stage.catehub.brockmann-consult.de
-REACT_APP_CATEHUB_ENDPOINT=http://localhost:8000
-REACT_APP_CATEHUB_WEBAPI_MANAG_PATH=/user/{username}/webapi
-REACT_APP_CATEHUB_WEBAPI_CLOSE_PATH=/user/{username}/webapi/shutdown
-REACT_APP_CATEHUB_WEBAPI_COUNT_PATH=/webapi/count
+REACT_APP_CATEHUB_ENDPOINT=https://stage.catehub.climate.esa.int/api/v2
+#REACT_APP_CATEHUB_ENDPOINT=http://localhost:8080/api/v2
+REACT_APP_CATEHUB_WEBAPI_MANAG_PATH=/users/{username}/webapis
+REACT_APP_CATEHUB_WEBAPI_CLOSE_PATH=/users/{username}/webapis
+REACT_APP_CATEHUB_WEBAPI_COUNT_PATH=/webapis

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,12 @@
 ### Changes 2.3.0 (in development)
 
-* ...
+* Optimisations in the DATA SOURCES panel (that have been enabled by 
+  using [xcube](https://xcube.readthedocs.io/) in the backend):
+  - Initalising the "ESA CCI Open Data Portal" data store
+    is now accellerated by a magnitude.
+  - Local caching of remote data sources when opening datasets 
+    is now much faster and more reliable.
+  - Ability to add more data stores has been greatly improved.
 
 ### Changes 2.2.3
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,10 +2,13 @@
 
 * Optimisations in the DATA SOURCES panel (that have been enabled by 
   using [xcube](https://xcube.readthedocs.io/) in the backend):
-  - Initalising the "ESA CCI Open Data Portal" data store
+  - Initalising the "CCI Open Data Portal" data store
     is now accellerated by a magnitude.
   - Local caching of remote data sources when opening datasets 
     is now much faster and more reliable.
+  - Added new experimental store "CCI Zarr Store" that offers
+    selected CCI datasets that have been converted to Zarr format 
+    and are read from JASMIN object storage.
   - Ability to add more data stores has been greatly improved.
 
 * We now obtain Cate Hub's status information from a dedicated GitHub 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,11 @@
 * We now obtain Cate Hub's status information from a dedicated GitHub 
   repository [cate-status](https://github.com/CCI-Tools/cate-status).
   
+* Adapted to changed cate-hub API. (An API response no longer has 
+  `status` and `result` properties, instead a response _is_ the result
+  and the response status is represented by the HTTP response code.)
+
+
 ### Changes 2.2.3
 
 * Fixed a problem that prevented using Matomo Analytics service.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,10 @@
-### Changes 2.3.0 (in development)
+### Changes 3.0 (in development)
+
+* Cate App 3.0 now requires the Web API service of the `cate 3.0+` 
+  Python package.
+
+* In order to keep alive the connection to the Web API service,
+  Cate App now sends a keepalive signal every 2.5 seconds. (#150)
 
 * Optimisations in the DATA SOURCES panel (that have been enabled by 
   using [xcube](https://xcube.readthedocs.io/) in the backend):

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,9 @@
     is now much faster and more reliable.
   - Ability to add more data stores has been greatly improved.
 
+* We now obtain Cate Hub's status information from a dedicated GitHub 
+  repository [cate-status](https://github.com/CCI-Tools/cate-status).
+  
 ### Changes 2.2.3
 
 * Fixed a problem that prevented using Matomo Analytics service.

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,7 @@
+### Changes 2.3.0 (in development)
+
+* ...
+
 ### Changes 2.2.3
 
 * Fixed a problem that prevented using Matomo Analytics service.

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:stretch-slim as build-deps
 
 LABEL maintainer="helge.dzierzon@brockmann-consult.de"
 LABEL name="Cate App"
-LABEL version="2.2.3"
+LABEL version="2.3.0-dev.0"
 
 RUN apt-get -y update && apt-get install -y git apt-utils wget vim
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:stretch-slim as build-deps
 
 LABEL maintainer="helge.dzierzon@brockmann-consult.de"
 LABEL name="Cate App"
-LABEL version="2.3.0-dev.1"
+LABEL version="2.3.0-dev.2"
 
 RUN apt-get -y update && apt-get install -y git apt-utils wget vim
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:stretch-slim as build-deps
 
 LABEL maintainer="helge.dzierzon@brockmann-consult.de"
 LABEL name="Cate App"
-LABEL version="2.3.0-dev.0"
+LABEL version="2.3.0-dev.1"
 
 RUN apt-get -y update && apt-get install -y git apt-utils wget vim
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:stretch-slim as build-deps
 
 LABEL maintainer="helge.dzierzon@brockmann-consult.de"
 LABEL name="Cate App"
-LABEL version="2.3.0-dev.3"
+LABEL version="2.3.0-dev.4"
 
 RUN apt-get -y update && apt-get install -y git apt-utils wget vim
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:stretch-slim as build-deps
 
 LABEL maintainer="helge.dzierzon@brockmann-consult.de"
 LABEL name="Cate App"
-LABEL version="2.3.0-dev.2"
+LABEL version="2.3.0-dev.3"
 
 RUN apt-get -y update && apt-get install -y git apt-utils wget vim
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:stretch-slim as build-deps
 
 LABEL maintainer="helge.dzierzon@brockmann-consult.de"
 LABEL name="Cate App"
-LABEL version="2.3.0-dev.4"
+LABEL version="3.0.0-dev.0"
 
 RUN apt-get -y update && apt-get install -y git apt-utils wget vim
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 2.3.0-dev.3-{build}
+version: 2.3.0-dev.4-{build}
 image: Ubuntu
 stack: node 12
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 2.3.0-dev.4-{build}
+version: 3.0.0-dev.0-{build}
 image: Ubuntu
 stack: node 12
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 2.2.3-{build}
+version: 2.3.0-dev.0-{build}
 image: Ubuntu
 stack: node 12
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 2.3.0-dev.2-{build}
+version: 2.3.0-dev.3-{build}
 image: Ubuntu
 stack: node 12
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 2.3.0-dev.1-{build}
+version: 2.3.0-dev.2-{build}
 image: Ubuntu
 stack: node 12
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 2.3.0-dev.0-{build}
+version: 2.3.0-dev.1-{build}
 image: Ubuntu
 stack: node 12
 install:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate-app",
-  "version": "2.3.0-dev.4",
+  "version": "3.0.0-dev.0",
   "private": true,
   "dependencies": {
     "@blueprintjs/core": "^3.30.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate-app",
-  "version": "2.3.0-dev.3",
+  "version": "2.3.0-dev.4",
   "private": true,
   "dependencies": {
     "@blueprintjs/core": "^3.30.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate-app",
-  "version": "2.3.0-dev.1",
+  "version": "2.3.0-dev.2",
   "private": true,
   "dependencies": {
     "@blueprintjs/core": "^3.30.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate-app",
-  "version": "2.3.0-dev.2",
+  "version": "2.3.0-dev.3",
   "private": true,
   "dependencies": {
     "@blueprintjs/core": "^3.30.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate-app",
-  "version": "2.2.3",
+  "version": "2.3.0-dev.0",
   "private": true,
   "dependencies": {
     "@blueprintjs/core": "^3.30.1",
@@ -50,6 +50,7 @@
     "@types/dom4": "^1.5.20",
     "@types/geojson": "^1.0.6",
     "@types/jest": "^24.0.0",
+    "@types/json-schema": "^7.0.7",
     "@types/mocha": "^2.2.41",
     "@types/node": "^12.0.0",
     "@types/oboe": "^2.0.28",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate-app",
-  "version": "2.3.0-dev.0",
+  "version": "2.3.0-dev.1",
   "private": true,
   "dependencies": {
     "@blueprintjs/core": "^3.30.1",

--- a/src/renderer/actions.spec.ts
+++ b/src/renderer/actions.spec.ts
@@ -122,7 +122,7 @@ describe('Actions', () => {
                 ]);
         });
 
-        it('updateDataSourceTemporalCoverage', () => {
+        it('updateDataSourceMetaInfo', () => {
             dispatch(actions.updateDataStores(
                 [
                     {id: 'local-1'},
@@ -133,9 +133,10 @@ describe('Actions', () => {
                                                    {id: 'fileset-1'},
                                                    {id: 'fileset-2'}
                                                ] as any));
-            dispatch(actions.updateDataSourceTemporalCoverage('local-2',
-                                                              'fileset-1',
-                                                              ['2010-01-01', '2014-12-30']));
+            dispatch(actions.updateDataSourceMetaInfo('local-2',
+                                                      'fileset-1',
+                                                      {'data_id': 'x', 'type_specifier': 'y'},
+                                                      'ok'));
             expect(getState().data.dataStores).to.deep.equal(
                 [
                     {id: 'local-1'},
@@ -143,7 +144,8 @@ describe('Actions', () => {
                         id: 'local-2', dataSources: [
                             {
                                 id: 'fileset-1',
-                                temporalCoverage: ['2010-01-01', '2014-12-30']
+                                metaInfo: {'data_id': 'x', 'type_specifier': 'y'},
+                                metaInfoStatus: 'ok',
                             },
                             {id: 'fileset-2'}
                         ]

--- a/src/renderer/actions.ts
+++ b/src/renderer/actions.ts
@@ -44,7 +44,8 @@ import {
     ControlState, DatasetDescriptor,
     DataSourceState,
     DataStoreState,
-    GeographicPosition, HubStatus,
+    GeographicPosition, 
+    HubStatus,
     ImageStatisticsState,
     LayerState,
     MessageState,
@@ -2757,4 +2758,3 @@ function readDroppedFile(file: File, dispatch: Dispatch) {
         console.warn('Dropped file of unrecognized type: ', file.name);
     }
 }
-

--- a/src/renderer/actions.ts
+++ b/src/renderer/actions.ts
@@ -44,7 +44,7 @@ import {
     ControlState, DatasetDescriptor,
     DataSourceState,
     DataStoreState,
-    GeographicPosition,
+    GeographicPosition, HubStatus,
     ImageStatisticsState,
     LayerState,
     MessageState,
@@ -138,6 +138,7 @@ export const SET_WEBAPI_STATUS = 'SET_WEBAPI_STATUS';
 export const SET_WEBAPI_CLIENT = 'SET_WEBAPI_CLIENT';
 export const SET_WEBAPI_SERVICE_URL = 'SET_WEBAPI_SERVICE_URL';
 export const SET_WEBAPI_SERVICE_INFO = 'SET_WEBAPI_SERVICE_INFO';
+export const UPDATE_HUB_STATUS = 'UPDATE_HUB_STATUS';
 export const UPDATE_DIALOG_STATE = 'UPDATE_DIALOG_STATE';
 export const UPDATE_TASK_STATE = 'UPDATE_TASK_STATE';
 export const REMOVE_TASK_STATE = 'REMOVE_TASK_STATE';
@@ -352,6 +353,10 @@ export function connectWebAPIService(webAPIServiceURL: string): ThunkAction {
             showToast({type: 'warning', text: formatMessage('Warning from Cate service', event)});
         };
     };
+}
+
+export function updateHubStatus(hubStatus: HubStatus): Action  {
+    return { type: UPDATE_HUB_STATUS, payload: hubStatus};
 }
 
 export function updateInitialState(initialState: Object): Action {

--- a/src/renderer/components/DataSourceDetails.tsx
+++ b/src/renderer/components/DataSourceDetails.tsx
@@ -23,20 +23,24 @@ const DataSourceDetails: React.FC<IDataSourceDetailsProps> = ({dataSource}) => {
     if (!dataSource) {
         return null;
     }
+
     let metaInfoKeys;
-    if (dataSource.metaInfo) {
-        metaInfoKeys = Object.keys(dataSource.metaInfo).filter(key => key !== 'variables');
-    }
     let variables;
-    if (dataSource.metaInfo.variables) {
-        variables = dataSource.metaInfo.variables;
+
+    const metaInfo = dataSource.metaInfo;
+
+    if (metaInfo) {
+        metaInfoKeys = Object.keys(metaInfo).filter(key => key !== 'variables');
+        if (metaInfo.variables) {
+            variables = metaInfo.variables;
+        }
     }
 
     const details: DetailPart[] = [
         renderAbstract(dataSource),
         renderVariablesTable(variables),
-        renderMetaInfoTable(dataSource.metaInfo, metaInfoKeys),
-        renderMetaInfoLicences(dataSource.metaInfo),
+        renderMetaInfoTable(metaInfo, metaInfoKeys),
+        renderMetaInfoLicences(metaInfo),
     ];
 
     return (
@@ -84,18 +88,26 @@ function renderAbstract(dataSource: DataSourceState): DetailPart {
                 </div>
             );
         }
-        if (dataSource.temporalCoverage) {
+        if (dataSource.metaInfo && dataSource.metaInfo.time_range) {
+            let [start, end] = dataSource.metaInfo.time_range;
+            if (!start && !end) {
+                start = end = 'unknown';
+            } else if (!start) {
+                start = 'unknown';
+            } else if (!end) {
+                end = 'today';
+            }
             temporalCoverage = (
                 <div><h5>Temporal coverage</h5>
                     <table>
                         <tbody>
                         <tr>
                             <td>Start</td>
-                            <td className="user-selectable">{dataSource.temporalCoverage[0]}</td>
+                            <td className="user-selectable">{start}</td>
                         </tr>
                         <tr>
                             <td>End</td>
-                            <td className="user-selectable">{dataSource.temporalCoverage[1]}</td>
+                            <td className="user-selectable">{end}</td>
                         </tr>
                         </tbody>
                     </table>

--- a/src/renderer/components/DataSourceItem.tsx
+++ b/src/renderer/components/DataSourceItem.tsx
@@ -36,20 +36,7 @@ interface DataSourceItemProps {
 const DataSourceItem: React.FC<DataSourceItemProps> = ({dataSource, showDataSourceIDs}) => {
     const metaInfo = dataSource.metaInfo;
 
-    // TODO: get rid of render logic here
-    const ecvId = ((metaInfo && metaInfo.cci_project) || '').toLowerCase();
-    const ecvMetaItem = ECV_META.ecvs[ecvId];
-    let backgroundColor, label;
-    if (ecvMetaItem) {
-        backgroundColor = ECV_META.colors[ecvMetaItem.color] || ecvMetaItem.color;
-        label = ecvMetaItem.label;
-    }
-    if (!backgroundColor) {
-        backgroundColor = ECV_META.colors["default"] || "#0BB7A0";
-    }
-    if (!label) {
-        label = ecvId.substr(0, 3).toUpperCase() || '?';
-    }
+    const {backgroundColor, label} = dataSourceToTextIconProps(dataSource);
     const icon = <div style={{...TEXT_ICON_STYLE, backgroundColor}}>{label}</div>;
 
     const title = dataSource.title || (metaInfo && metaInfo.title);
@@ -82,3 +69,34 @@ const DataSourceItem: React.FC<DataSourceItemProps> = ({dataSource, showDataSour
 
 
 export default DataSourceItem;
+
+
+function dataSourceToTextIconProps(dataSource: DataSourceState) {
+    let ecvId;
+    let label;
+    if (dataSource.title) {
+        ecvId = dataSource.title.split(' ', 1)[0].toLowerCase();
+        label = dataSource.title.substr(0, 3).toUpperCase();
+    }
+    if (!ecvId || !ECV_META.ecvs[ecvId]) {
+        // This is a CCI-store specific hack
+        const idParts = dataSource.id.split('.', 2);
+        if (idParts.length > 1) {
+            ecvId = idParts[1].toLowerCase();
+        }
+    }
+    const ecvMetaItem = ecvId && ECV_META.ecvs[ecvId];
+    let backgroundColor;
+    if (ecvMetaItem) {
+        backgroundColor = ECV_META.colors[ecvMetaItem.color] || ecvMetaItem.color;
+        label = ecvMetaItem.label || label;
+    }
+    if (!backgroundColor) {
+        backgroundColor = ECV_META.colors["default"] || "#0BB7A0";
+    }
+    if (!label) {
+        label = (ecvId && ecvId.substr(0, 3).toUpperCase()) || '?';
+    }
+    return {backgroundColor, label};
+}
+

--- a/src/renderer/containers/AppModePage.tsx
+++ b/src/renderer/containers/AppModePage.tsx
@@ -9,12 +9,9 @@ import GdprBanner from './GdprBanner';
 import { TermsAndConditions } from '../components/TermsAndConditions';
 import { DEFAULT_SERVICE_URL } from '../initial-state';
 import { State } from '../state';
-
 import cateIcon from '../resources/cate-icon-512.png';
 import VersionTags from './VersionTags';
 
-
-const maintenanceReason: string | undefined = process.env.REACT_APP_CATEHUB_MAINTENANCE;
 
 const CENTER_DIV_STYLE: CSSProperties = {
     display: 'flex',
@@ -40,14 +37,24 @@ interface IDispatch {
 }
 
 interface IAppModePageProps {
+    hubOk?: boolean;
+    hubMessage?: string | null;
 }
 
 // noinspection JSUnusedLocalSymbols
 function mapStateToProps(state: State): IAppModePageProps {
-    return {};
+    const hubStatus = state.communication.hubStatus;
+    return {
+        hubOk: !!hubStatus && hubStatus.status === 'ok',
+        hubMessage: hubStatus && hubStatus.message,
+    };
 }
 
-const _AppModePage: React.FC<IAppModePageProps & IDispatch> = () => {
+const _AppModePage: React.FC<IAppModePageProps & IDispatch> = (
+    {
+        hubOk,
+        hubMessage
+    }) => {
 
     const history = useHistory();
     const [, keycloakInitialized] = useKeycloak();
@@ -96,21 +103,24 @@ const _AppModePage: React.FC<IAppModePageProps & IDispatch> = () => {
                     <img src={cateIcon} width={128} height={128} alt={'Cate icon'}/>
                 </div>
 
-                {maintenanceReason ? (
-                    <div style={{marginTop: 12, alignContent: 'center', textAlign: 'center', maxWidth: 320}}>
-                        <Icon icon="warning-sign" intent={Intent.WARNING}/>&nbsp;{maintenanceReason}
+                {hubOk && (
+                    <div style={{marginTop: 12, alignContent: 'center', textAlign: 'center', maxWidth: 360}}>
+                        Please select a Cate service provision mode
                     </div>
-                ) : (
-                     <div style={{marginTop: 12, alignContent: 'center', textAlign: 'center', maxWidth: 320}}>
-                         Please select a Cate service provision mode
-                     </div>
-                 )}
+                )}
+
+                {hubMessage && (
+                    <div style={{marginTop: 12, alignContent: 'center', textAlign: 'center', maxWidth: 360}}>
+                        <Icon icon="warning-sign" intent={Intent.WARNING}/>&nbsp;{hubMessage}
+                    </div>
+                )}
+
                 <Button className={'bp3-large'}
                         intent={Intent.PRIMARY}
                         style={{marginTop: 18}}
                         onClick={setCateHubMode}
-                        disabled={!keycloakInitialized || !termsAndConditionsAgreed || Boolean(maintenanceReason)}
-                        rightIcon={maintenanceReason ? null : !keycloakInitialized && <Spinner size={16}/>}
+                        disabled={!keycloakInitialized || !termsAndConditionsAgreed || !hubOk}
+                        rightIcon={hubOk ? null : !keycloakInitialized && <Spinner size={16}/>}
                 >
                     <Tooltip content={<div>Obtain a new Cate service instance<br/>in the cloud (CateHub
                         Software-as-a-Service).<br/>Requires login information.</div>}>
@@ -121,7 +131,7 @@ const _AppModePage: React.FC<IAppModePageProps & IDispatch> = () => {
                     <Checkbox
                         checked={termsAndConditionsAgreed}
                         onChange={handleTermsAndConditionsAgreedChange}
-                        disabled={Boolean(maintenanceReason)}
+                        disabled={!hubOk}
                     >
                         I agree to the&nbsp;<TermsAndConditions/>
                     </Checkbox>

--- a/src/renderer/containers/AppRouter.tsx
+++ b/src/renderer/containers/AppRouter.tsx
@@ -30,7 +30,10 @@ const AppRouter: React.FC<IAppRouterProps> = ({hubStatus}) => {
                 </Route>
                 <Route path="/hub">
                     {
-                        (hubStatus === null || hubStatus.status !== 'ok')
+                        // It should read
+                        //   (hubStatus === null || hubStatus.status !== 'ok')
+                        // but this will always bring us back to "/" after login :(
+                        (hubStatus !== null && hubStatus.status !== 'ok')
                         ? (<Redirect to="/"/>)
                         : (<AppMainPageForHub/>)
                     }

--- a/src/renderer/containers/AppRouter.tsx
+++ b/src/renderer/containers/AppRouter.tsx
@@ -1,0 +1,43 @@
+import * as React from 'react';
+import { connect } from 'react-redux';
+import { BrowserRouter as Router, Redirect, Route, Switch } from "react-router-dom";
+
+import { State, HubStatus } from '../state';
+import AppMainPageForHub from '../containers/AppMainPageForHub';
+import AppMainPageForSA from './AppMainPageForSA';
+import AppModePage from './AppModePage';
+
+
+interface IAppRouterProps {
+    hubStatus: HubStatus | null;
+}
+
+function mapStateToProps(state: State): IAppRouterProps {
+    return {
+        hubStatus: state.communication.hubStatus
+    };
+}
+
+const AppRouter: React.FC<IAppRouterProps> = ({hubStatus}) => {
+    return (
+        <Router>
+            <Switch>
+                <Route exact path="/">
+                    <AppModePage/>
+                </Route>
+                <Route path="/sa">
+                    <AppMainPageForSA/>
+                </Route>
+                <Route path="/hub">
+                    {
+                        (hubStatus === null || hubStatus.status !== 'ok')
+                        ? (<Redirect to="/"/>)
+                        : (<AppMainPageForHub/>)
+                    }
+                </Route>
+            </Switch>
+        </Router>
+    );
+}
+
+export default connect(mapStateToProps)(AppRouter);

--- a/src/renderer/containers/DataSourcesPanel.tsx
+++ b/src/renderer/containers/DataSourcesPanel.tsx
@@ -97,7 +97,7 @@ interface IDataSourcesPanelDispatch {
 
     updateSessionState(sessionState: any): void;
 
-    loadTemporalCoverage(dataStoreId: string, dataSourceId: string): void;
+    loadDataSourceMetaInfo(dataStoreId: string, dataSourceId: string): void;
 
     showDialog(dialogId: string): void;
 
@@ -111,7 +111,6 @@ const mapDispatchToProps = {
     setSessionState: actions.setSessionProperty,
     setControlState: actions.setControlProperty,
     updateSessionState: actions.updateSessionState,
-    loadTemporalCoverage: actions.loadTemporalCoverage,
     showDialog: actions.showDialog,
     hideDialog: actions.hideDialog,
 };
@@ -260,14 +259,7 @@ class DataSourcesPanel extends React.Component<IDataSourcesPanelProps & IDataSou
     }
 
     private handleShowOpenDatasetDialog() {
-        this.maybeLoadTemporalCoverage();
         this.props.showDialog('openDatasetDialog');
-    }
-
-    private maybeLoadTemporalCoverage() {
-        if (!this.props.selectedDataSource.temporalCoverage) {
-            this.props.loadTemporalCoverage(this.props.selectedDataStore.id, this.props.selectedDataSource.id);
-        }
     }
 
     private handleDataStoreSelected(event) {

--- a/src/renderer/initial-state.ts
+++ b/src/renderer/initial-state.ts
@@ -143,6 +143,7 @@ export const INITIAL_COMMUNICATION_STATE: CommunicationState = {
     webAPIStatus: null,
     webAPIServiceInfo: null,
     webAPIClient: null,
+    hubStatus: null,
     userProfile: null,
     tasks: {},
 };

--- a/src/renderer/reducers.ts
+++ b/src/renderer/reducers.ts
@@ -841,6 +841,12 @@ const communicationReducer = (state: CommunicationState = INITIAL_COMMUNICATION_
             const webAPIServiceInfo = action.payload.webAPIServiceInfo;
             return {...state, webAPIServiceInfo};
         }
+        case actions.UPDATE_HUB_STATUS: {
+            return {
+                ...state,
+                hubStatus: action.payload
+            }
+        }
         case actions.UPDATE_TASK_STATE:
             return {
                 ...state,

--- a/src/renderer/reducers.ts
+++ b/src/renderer/reducers.ts
@@ -111,17 +111,16 @@ const dataReducer = (state: DataState = INITIAL_DATA_STATE, action: Action): Dat
                 return action.payload.dataSources.slice();
             });
         }
-        case actions.UPDATE_DATA_SOURCE_TEMPORAL_COVERAGE: {
+        case actions.UPDATE_DATA_SOURCE_META_INFO: {
             return updateDataStores(state, action, dataStore => {
                 const newDataSources = [...dataStore.dataSources];
-                const dataSourceId = action.payload.dataSourceId;
-                const temporalCoverage = action.payload.temporalCoverage;
+                const {dataSourceId, metaInfo, metaInfoStatus} = action.payload;
                 const dataSourceIndex = newDataSources.findIndex(dataSource => dataSource.id === dataSourceId);
                 if (dataSourceIndex < 0) {
                     throw Error('illegal data source ID: ' + dataSourceId);
                 }
                 const oldDataSource = newDataSources[dataSourceIndex];
-                newDataSources[dataSourceIndex] = {...oldDataSource, temporalCoverage};
+                newDataSources[dataSourceIndex] = {...oldDataSource, metaInfo, metaInfoStatus};
                 return newDataSources;
             });
         }

--- a/src/renderer/selectors.ts
+++ b/src/renderer/selectors.ts
@@ -440,12 +440,15 @@ export const selectedDataSourceSelector = createSelector<State, DataSourceState 
     }
 );
 
-export const selectedDataSourceTemporalCoverageSelector = createSelector<State, [string, string] | null,
+export const selectedDataSourceTemporalCoverageSelector = createSelector<State,
+    [string | null, string | null] | null,
     DataSourceState
     | null>(
     selectedDataSourceSelector,
-    (selectedDataSource: DataSourceState): [string, string] | null => {
-        return selectedDataSource ? selectedDataSource.temporalCoverage : null;
+    (selectedDataSource: DataSourceState): [string | null, string | null] | null => {
+        return (selectedDataSource
+                && selectedDataSource.metaInfo
+                && selectedDataSource.metaInfo.time_range) || null;
     }
 );
 

--- a/src/renderer/selectors.ts
+++ b/src/renderer/selectors.ts
@@ -452,9 +452,15 @@ export const selectedDataSourceTemporalCoverageSelector = createSelector<State,
     }
 );
 
-export const canCacheDataSourceSelector = createSelector<State, boolean, DataSourceState | null>(
+export const canCacheDataSourceSelector = createSelector<State, boolean, string | null, DataSourceState | null>(
+    selectedDataStoreIdSelector,
     selectedDataSourceSelector,
-    (selectedDataSource: DataSourceState | null): boolean => {
+    (selectedDataStoreId, selectedDataSource): boolean => {
+        if (selectedDataStoreId === null
+            || selectedDataStoreId === 'local'
+            || selectedDataStoreId === 'cci-zarr-store') {
+            return false;
+        }
         return selectedDataSource ? canCacheDataSource(selectedDataSource) : false;
     }
 );

--- a/src/renderer/state-util.ts
+++ b/src/renderer/state-util.ts
@@ -251,6 +251,20 @@ export function findOperation(operations: OperationState[], name: string): Opera
     return operations && operations.find(op => op.qualifiedName === name || op.name === name);
 }
 
+export function findDataSource(dataStores: DataStoreState[],
+                               dataStoreId: string,
+                               dataSourceId: string): DataSourceState | null {
+    const dataStore = dataStores && dataStores.find(dataStore => dataStore.id === dataStoreId);
+    if (dataStore) {
+        const dataSource = dataStore.dataSources
+                           && dataStore.dataSources.find(dataSource => dataSource.id === dataSourceId);
+        if (dataSource) {
+            return dataSource;
+        }
+    }
+    return null;
+}
+
 export function findVariableIndexCoordinates(resources: ResourceState[], ref: VariableDataRefState): any[] {
     const resource = findResourceById(resources, ref.resId);
     if (!resource) {

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -1,5 +1,6 @@
 import { IconName } from '@blueprintjs/core';
 import { Feature, FeatureCollection, GeoJsonObject, Point } from 'geojson';
+import { JSONSchema7 } from 'json-schema';
 import { KeycloakProfile } from 'keycloak-js';
 
 import { SimpleStyle } from '../common/geojson-simple-style';
@@ -85,10 +86,68 @@ export interface DataStoreState {
 
 export type DataSourceVerificationFlags = "open" | "cache" | "map";
 
+
+export interface DatasetDescriptor {
+    data_id: string;
+    type_specifier: string;
+    crs?: string;
+    bbox?: [number, number, number, number];
+    spatial_res?: number;
+    time_range?: [string | null, string | null];
+    time_period?: string;
+    variables?: { [var_name: string]: VariableDescriptor };
+
+    [attr_name: string]: any;
+}
+
+export interface VariableDescriptor {
+    name: string;
+    units: string;
+    long_name: string;
+    standard_name: string;
+}
+
+// TODO: (forman) use this in the future instead of DatasetDescriptor/VariableDescriptor
+// {{{{{{{{{{{{
+
+export interface DataDescriptor2 {
+    data_id: string;
+    type_specifier: string;
+    crs?: string | null;
+    bbox?: [number, number, number, number] | null;
+    time_range?: [string | null, string | null] | null;
+    time_period?: string | null;
+    open_params_schema?: JSONSchema7 | null;
+}
+
+export interface GeoDataFrameDescriptor2 extends DataDescriptor2 {
+}
+
+export interface DatasetDescriptor2 extends DataDescriptor2 {
+    spatial_res?: number | null;
+    dims?: { [dim_name: string]: number } | null;
+    coords?: { [var_name: string]: VariableDescriptor2 } | null;
+    data_vars?: { [var_name: string]: VariableDescriptor2 } | null;
+    attrs?: { [attr_name: string]: any } | null;
+}
+
+export interface VariableDescriptor2 {
+    name: string;
+    dtype: string;
+    dims: string[];
+    chunks?: number[] | null;
+    attrs?: { [attr_name: string]: any } | null;
+}
+// }}}}}}}}}}}}
+
+
 export interface DataSourceState {
     id: string;
     title?: string;
-    metaInfo: { [key: string]: any } | null;
+    // TODO: (forman) replace by descriptor in the future
+    metaInfo?: DatasetDescriptor;
+    // TODO: (forman) use this in the future instead of metaInfo
+    descriptor?: DatasetDescriptor2 | GeoDataFrameDescriptor2;
     typeSpecifier?: string | null;
     verificationFlags?: DataSourceVerificationFlags[] | null;
     temporalCoverage?: [string, string] | null;

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -96,15 +96,23 @@ export interface DatasetDescriptor {
     time_range?: [string | null, string | null];
     time_period?: string;
     variables?: VariableDescriptor[];
+    abstract?: string;
+    catalog_url?: string;
+    catalogue_url?: string;
+    cci_project?: string;
+    info_url?: string;
+    licences?: [string];
+    title?: string;
+    uuid?: string;
 
     [attr_name: string]: any;
 }
 
 export interface VariableDescriptor {
     name: string;
-    units: string;
-    long_name: string;
-    standard_name: string;
+    units?: string;
+    long_name?: string;
+    standard_name?: string;
 }
 
 // TODO: (forman) use this in the future instead of DatasetDescriptor/VariableDescriptor

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -67,6 +67,12 @@ export interface WebAPIServiceInfo {
     hostOS?: HostOS;
 }
 
+export interface HubStatus {
+    status: "ok" | "offline";
+    message?: string;
+    deployment: "development" | "production";
+}
+
 export interface DataStoreNotice {
     id: string;
     title: string;
@@ -727,6 +733,7 @@ export interface CommunicationState {
     webAPIStatus: WebAPIStatus | null;
     webAPIClient: WebAPIClient | null;
     userProfile: KeycloakProfile | null;
+    hubStatus: HubStatus | null;
     // A map that stores the current state of any tasks (e.g. data fetch jobs from remote API) given a jobId
     tasks: { [jobId: number]: TaskState; };
 }

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -104,7 +104,7 @@ export interface DatasetDescriptor {
     licences?: [string];
     title?: string;
     uuid?: string;
-
+    // Anything else:
     [attr_name: string]: any;
 }
 
@@ -154,8 +154,10 @@ export interface DataSourceState {
     title?: string;
     // TODO: (forman) replace by descriptor in the future
     metaInfo?: DatasetDescriptor;
+    metaInfoStatus: 'init' | 'loading' | 'ok' | 'error';
     // TODO: (forman) use this in the future instead of metaInfo
-    descriptor?: DatasetDescriptor2 | GeoDataFrameDescriptor2;
+    // descriptor?: DatasetDescriptor2 | GeoDataFrameDescriptor2;
+    // descriptorStatus: 'init' | 'loading' | 'ok' | 'error';
     typeSpecifier?: string | null;
     verificationFlags?: DataSourceVerificationFlags[] | null;
     temporalCoverage?: [string, string] | null;

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -95,7 +95,7 @@ export interface DatasetDescriptor {
     spatial_res?: number;
     time_range?: [string | null, string | null];
     time_period?: string;
-    variables?: { [var_name: string]: VariableDescriptor };
+    variables?: VariableDescriptor[];
 
     [attr_name: string]: any;
 }

--- a/src/renderer/webapi/WebSocketMock.ts
+++ b/src/renderer/webapi/WebSocketMock.ts
@@ -4,6 +4,8 @@
  * @author Norman Fomferra
  */
 export interface WebSocketMin {
+    readonly readyState: number;
+
     onclose: (this: this, ev: CloseEvent) => any;
     onerror: (this: this, ev: ErrorEvent) => any;
     onmessage: (this: this, ev: MessageEvent) => any;
@@ -52,6 +54,7 @@ export class WebSocketMock implements WebSocketMin {
     onclose: (this: this, ev: any) => any;
     readonly messageLog: string[] = [];
     readonly serviceObj: any;
+    readyState: number;
 
     // <<<< WebSocketMin implementation
     ////////////////////////////////////////////
@@ -68,6 +71,7 @@ export class WebSocketMock implements WebSocketMin {
         }
         this.serviceObj = serviceObj;
         this.asyncCalls = asyncCalls;
+        this.readyState = WebSocket.CONNECTING;
     }
 
     send(data: string) {
@@ -77,6 +81,7 @@ export class WebSocketMock implements WebSocketMin {
 
     close(code?: number, reason?: string): void {
         this.onclose({code, reason});
+        this.readyState = WebSocket.CLOSED;
     }
 
     emulateIncomingMessages(...messages: Object[]) {
@@ -95,14 +100,19 @@ export class WebSocketMock implements WebSocketMin {
 
     emulateOpen(event) {
         this.onopen(event);
+        this.readyState = WebSocket.OPEN;
     }
 
     emulateError(event) {
+        this.readyState = WebSocket.CLOSING;
         this.onerror(event);
+        this.readyState = WebSocket.CLOSED;
     }
 
     emulateClose(event) {
+        this.readyState = WebSocket.CLOSING;
         this.onclose(event);
+        this.readyState = WebSocket.CLOSED;
     }
 
     private maybeUseServiceObj(messageText) {

--- a/src/renderer/webapi/apis/ServiceProvisionAPI.ts
+++ b/src/renderer/webapi/apis/ServiceProvisionAPI.ts
@@ -34,6 +34,9 @@ interface CountResult {
     running_pods: number;
 }
 
+/**
+ * Represents the cate-hub API.
+ */
 export class ServiceProvisionAPI {
 
     /**
@@ -81,11 +84,7 @@ export class ServiceProvisionAPI {
         if (!response.ok) {
             throw HttpError.fromResponse(response);
         }
-        const jsonObject = await response.json();
-        if (jsonObject.status !== 'ok') {
-            throw new Error(jsonObject.message);
-        }
-        return jsonObject.result as T;
+        return response.json();
     }
 }
 

--- a/src/renderer/webapi/apis/ServiceProvisionAPI.ts
+++ b/src/renderer/webapi/apis/ServiceProvisionAPI.ts
@@ -89,8 +89,7 @@ export class ServiceProvisionAPI {
     }
 }
 
-
-function getEndpointUrl(): string {
+export function getEndpointUrl(): string {
     if (process.env.REACT_APP_CATEHUB_ENDPOINT) {
         return process.env.REACT_APP_CATEHUB_ENDPOINT;
     } else if (window.location.host.indexOf('stage') >= 0) {

--- a/src/serviceWorker.ts
+++ b/src/serviceWorker.ts
@@ -14,7 +14,7 @@
 // "./service-worker.js" file changes). Therefore we use a version number here,
 // so we can force updates.
 //
-const CATE_PWA_VERSION = "2.3.0-dev.0";
+const CATE_PWA_VERSION = "2.3.0-dev.1";
 
 console.debug(`Cate PWA version ${CATE_PWA_VERSION}`);
 

--- a/src/serviceWorker.ts
+++ b/src/serviceWorker.ts
@@ -14,7 +14,7 @@
 // "./service-worker.js" file changes). Therefore we use a version number here,
 // so we can force updates.
 //
-const CATE_PWA_VERSION = "2.3.0-dev.2";
+const CATE_PWA_VERSION = "2.3.0-dev.3";
 
 console.debug(`Cate PWA version ${CATE_PWA_VERSION}`);
 

--- a/src/serviceWorker.ts
+++ b/src/serviceWorker.ts
@@ -14,7 +14,7 @@
 // "./service-worker.js" file changes). Therefore we use a version number here,
 // so we can force updates.
 //
-const CATE_PWA_VERSION = "2.2.3";
+const CATE_PWA_VERSION = "2.3.0-dev.0";
 
 console.debug(`Cate PWA version ${CATE_PWA_VERSION}`);
 

--- a/src/serviceWorker.ts
+++ b/src/serviceWorker.ts
@@ -14,7 +14,7 @@
 // "./service-worker.js" file changes). Therefore we use a version number here,
 // so we can force updates.
 //
-const CATE_PWA_VERSION = "2.3.0-dev.4";
+const CATE_PWA_VERSION = "3.0.0-dev.0";
 
 console.debug(`Cate PWA version ${CATE_PWA_VERSION}`);
 

--- a/src/serviceWorker.ts
+++ b/src/serviceWorker.ts
@@ -14,7 +14,7 @@
 // "./service-worker.js" file changes). Therefore we use a version number here,
 // so we can force updates.
 //
-const CATE_PWA_VERSION = "2.3.0-dev.1";
+const CATE_PWA_VERSION = "2.3.0-dev.2";
 
 console.debug(`Cate PWA version ${CATE_PWA_VERSION}`);
 

--- a/src/serviceWorker.ts
+++ b/src/serviceWorker.ts
@@ -14,7 +14,7 @@
 // "./service-worker.js" file changes). Therefore we use a version number here,
 // so we can force updates.
 //
-const CATE_PWA_VERSION = "2.3.0-dev.3";
+const CATE_PWA_VERSION = "2.3.0-dev.4";
 
 console.debug(`Cate PWA version ${CATE_PWA_VERSION}`);
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -2,4 +2,4 @@
 // 1. with the version field in "../package.json".
 // 2. with CATE_PWA_VERSION in "./serviceWorker.ts"
 //
-export const CATE_APP_VERSION = "2.3.0-dev.0";
+export const CATE_APP_VERSION = "2.3.0-dev.1";

--- a/src/version.ts
+++ b/src/version.ts
@@ -2,4 +2,4 @@
 // 1. with the version field in "../package.json".
 // 2. with CATE_PWA_VERSION in "./serviceWorker.ts"
 //
-export const CATE_APP_VERSION = "2.3.0-dev.2";
+export const CATE_APP_VERSION = "2.3.0-dev.3";

--- a/src/version.ts
+++ b/src/version.ts
@@ -2,4 +2,4 @@
 // 1. with the version field in "../package.json".
 // 2. with CATE_PWA_VERSION in "./serviceWorker.ts"
 //
-export const CATE_APP_VERSION = "2.3.0-dev.3";
+export const CATE_APP_VERSION = "2.3.0-dev.4";

--- a/src/version.ts
+++ b/src/version.ts
@@ -2,4 +2,4 @@
 // 1. with the version field in "../package.json".
 // 2. with CATE_PWA_VERSION in "./serviceWorker.ts"
 //
-export const CATE_APP_VERSION = "2.3.0-dev.1";
+export const CATE_APP_VERSION = "2.3.0-dev.2";

--- a/src/version.ts
+++ b/src/version.ts
@@ -2,4 +2,4 @@
 // 1. with the version field in "../package.json".
 // 2. with CATE_PWA_VERSION in "./serviceWorker.ts"
 //
-export const CATE_APP_VERSION = "2.3.0-dev.4";
+export const CATE_APP_VERSION = "3.0.0-dev.0";

--- a/src/version.ts
+++ b/src/version.ts
@@ -2,4 +2,4 @@
 // 1. with the version field in "../package.json".
 // 2. with CATE_PWA_VERSION in "./serviceWorker.ts"
 //
-export const CATE_APP_VERSION = "2.2.3";
+export const CATE_APP_VERSION = "2.3.0-dev.0";

--- a/yarn.lock
+++ b/yarn.lock
@@ -1772,6 +1772,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.5.tgz#dcce4430e64b443ba8945f0290fb564ad5bac6dd"
   integrity sha512-7+2BITlgjgDhH0vvwZU/HZJVyk+2XUlvxXe8dFMedNX/aMkaOq++rMAFXc0tM7ij15QaWlbdQASBR9dihi+bDQ==
 
+"@types/json-schema@^7.0.7":
+  version "7.0.7"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.7.tgz#98a993516c859eb0d5c4c8f098317a9ea68db9ad"
+  integrity sha512-cxWFQVseBm6O9Gbw1IWb8r6OS4OhSt3hPZLkFApLjM8TEXROBuQGLAH2i2gZpcXdLBIrpXuTDhH7Vbm1iXmNGA==
+
 "@types/minimatch@*":
   version "3.0.3"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-3.0.3.tgz#3dca0e3f33b200fc7d1139c0cd96c1268cadfd9d"


### PR DESCRIPTION
### Changes 2.3.0 (in development)

* Cate App 3.0 now requires the Web API service of the `cate 3.0+` 
  Python package.

* In order to keep alive the connection to the Web API service,
  Cate App now sends a keepalive signal every 2.5 seconds. (#150)

* Optimisations in the DATA SOURCES panel (that have been enabled by 
  using [xcube](https://xcube.readthedocs.io/) in the backend):
  - Initalising the "ESA CCI Open Data Portal" data store
    is now accellerated by a magnitude.
  - Local caching of remote data sources when opening datasets 
    is now much faster and more reliable.
  - Ability to add more data stores has been greatly improved.

* We now obtain Cate Hub's status information from a dedicated GitHub 
  repository [cate-status](https://github.com/CCI-Tools/cate-status).