### PR TITLE
Corrected performServiceOp. The hub's response object has changed.

### DIFF
--- a/.env
+++ b/.env
@@ -14,8 +14,8 @@ REACT_APP_KEYCLOAK_CLIENT_ID=cate-webui
 # REACT_APP_MAX_NUM_USERS=50
 
 # TODO: document me
-# REACT_APP_CATEHUB_ENDPOINT=https://stage.catehub.brockmann-consult.de
-REACT_APP_CATEHUB_ENDPOINT=http://localhost:8000
-REACT_APP_CATEHUB_WEBAPI_MANAG_PATH=/user/{username}/webapi
-REACT_APP_CATEHUB_WEBAPI_CLOSE_PATH=/user/{username}/webapi/shutdown
-REACT_APP_CATEHUB_WEBAPI_COUNT_PATH=/webapi/count
+REACT_APP_CATEHUB_ENDPOINT=https://stage.catehub.climate.esa.int/api/v2
+#REACT_APP_CATEHUB_ENDPOINT=http://localhost:8080/api/v2
+REACT_APP_CATEHUB_WEBAPI_MANAG_PATH=/users/{username}/webapis
+REACT_APP_CATEHUB_WEBAPI_CLOSE_PATH=/users/{username}/webapis
+REACT_APP_CATEHUB_WEBAPI_COUNT_PATH=/webapis

--- a/src/renderer/webapi/apis/ServiceProvisionAPI.ts
+++ b/src/renderer/webapi/apis/ServiceProvisionAPI.ts
@@ -82,10 +82,8 @@ export class ServiceProvisionAPI {
             throw HttpError.fromResponse(response);
         }
         const jsonObject = await response.json();
-        if (jsonObject.status !== 'ok') {
-            throw new Error(jsonObject.message);
-        }
-        return jsonObject.result as T;
+
+        return jsonObject as T;
     }
 }
 


### PR DESCRIPTION
When accepting this PR the cate-app will not throw errors anymore when it cannot find 'status' and 'result' in teh xcube-hub's response object. Result and status have been removed in xcube-hub API v2.0.0.