### PR TITLE
Adapted to changed cate-hub API

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,11 @@
 * We now obtain Cate Hub's status information from a dedicated GitHub 
   repository [cate-status](https://github.com/CCI-Tools/cate-status).
   
+* Adapted to changed cate-hub API. (An API response no longer has 
+  `status` and `result` properties, instead a response _is_ the result
+  and the response status is represented by the HTTP response code.)
+
+
 ### Changes 2.2.3
 
 * Fixed a problem that prevented using Matomo Analytics service.

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM node:stretch-slim as build-deps
 
 LABEL maintainer="helge.dzierzon@brockmann-consult.de"
 LABEL name="Cate App"
-LABEL version="2.3.0-dev.1"
+LABEL version="2.3.0-dev.2"
 
 RUN apt-get -y update && apt-get install -y git apt-utils wget vim
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 2.3.0-dev.1-{build}
+version: 2.3.0-dev.2-{build}
 image: Ubuntu
 stack: node 12
 install:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate-app",
-  "version": "2.3.0-dev.1",
+  "version": "2.3.0-dev.2",
   "private": true,
   "dependencies": {
     "@blueprintjs/core": "^3.30.1",

--- a/src/renderer/webapi/apis/ServiceProvisionAPI.ts
+++ b/src/renderer/webapi/apis/ServiceProvisionAPI.ts
@@ -34,6 +34,9 @@ interface CountResult {
     running_pods: number;
 }
 
+/**
+ * Represents the cate-hub API.
+ */
 export class ServiceProvisionAPI {
 
     /**
@@ -81,11 +84,7 @@ export class ServiceProvisionAPI {
         if (!response.ok) {
             throw HttpError.fromResponse(response);
         }
-        const jsonObject = await response.json();
-        if (jsonObject.status !== 'ok') {
-            throw new Error(jsonObject.message);
-        }
-        return jsonObject.result as T;
+        return response.json();
     }
 }
 

--- a/src/serviceWorker.ts
+++ b/src/serviceWorker.ts
@@ -14,7 +14,7 @@
 // "./service-worker.js" file changes). Therefore we use a version number here,
 // so we can force updates.
 //
-const CATE_PWA_VERSION = "2.3.0-dev.1";
+const CATE_PWA_VERSION = "2.3.0-dev.2";
 
 console.debug(`Cate PWA version ${CATE_PWA_VERSION}`);
 

--- a/src/version.ts
+++ b/src/version.ts
@@ -2,4 +2,4 @@
 // 1. with the version field in "../package.json".
 // 2. with CATE_PWA_VERSION in "./serviceWorker.ts"
 //
-export const CATE_APP_VERSION = "2.3.0-dev.1";
+export const CATE_APP_VERSION = "2.3.0-dev.2";


### PR DESCRIPTION
* Adapted to changed cate-hub API. (An API response no longer has 
  `status` and `result` properties, instead a response _is_ the result
  and the response status is represented by the HTTP response code.)