### PR TITLE
Exploit the more complete DatasetDescriptor

### DIFF
--- a/src/renderer/components/DataSourceDetails.tsx
+++ b/src/renderer/components/DataSourceDetails.tsx
@@ -35,11 +35,13 @@ const DataSourceDetails: React.FC<IDataSourceDetailsProps> = ({dataSource}) => {
     let variables;
 
     const metaInfo = dataSource.metaInfo;
+    console.log('metaInfo', metaInfo);
 
     if (metaInfo) {
-        metaInfoKeys = Object.keys(metaInfo).filter(key => key !== 'variables');
-        if (metaInfo.variables) {
-            variables = metaInfo.variables;
+        metaInfoKeys = Object.keys(metaInfo).filter(key => key !== 'data_vars'
+                                                           && key !== 'coords');
+        if (metaInfo.data_vars) {
+            variables = metaInfo.data_vars;
         }
     }
 

--- a/src/renderer/containers/DataAccessComponent.tsx
+++ b/src/renderer/containers/DataAccessComponent.tsx
@@ -112,11 +112,11 @@ export class DataAccessComponent extends React.Component<IDataAccessComponentPro
     private static dataSourceToResource(dataSource: DataSourceState): ResourceState {
         if (dataSource) {
             const metaInfo = dataSource.metaInfo;
-            if (metaInfo && metaInfo.variables && metaInfo.variables.length) {
+            if (metaInfo && metaInfo.data_vars && metaInfo.data_vars.length) {
                 return {
                     name: dataSource.id,
                     dataType: types.DATASET_TYPE,
-                    variables: metaInfo.variables.map(v => DataAccessComponent.dataSourceVarToVariable(v)),
+                    variables: metaInfo.data_vars.map(v => DataAccessComponent.dataSourceVarToVariable(v)),
                 } as ResourceState;
             }
         }

--- a/src/renderer/containers/OpenDatasetDialog.tsx
+++ b/src/renderer/containers/OpenDatasetDialog.tsx
@@ -16,7 +16,9 @@ interface IOpenDatasetDialogProps {
     dataStore: DataStoreState | null;
     dataSource: DataSourceState | null;
     temporalCoverage: TimeRangeValue | null;
-    canMap: boolean;
+    canConstrainTime: boolean;
+    canConstrainRegion: boolean;
+    canConstrainVariables: boolean;
     canCache: boolean;
     options: IDataAccessComponentOptions;
 }
@@ -32,7 +34,9 @@ function mapStateToProps(state: State): IOpenDatasetDialogProps {
         dataStore: selectors.selectedDataStoreSelector(state),
         dataSource: selectors.selectedDataSourceSelector(state),
         temporalCoverage: selectors.selectedDataSourceTemporalCoverageSelector(state),
-        canMap: selectors.canMapDataSourceSelector(state),
+        canConstrainTime: selectors.canConstrainDataSourceTimeSelector(state),
+        canConstrainRegion: selectors.canConstrainDataSourceRegionSelector(state),
+        canConstrainVariables: selectors.canConstrainDataSourceVariablesSelector(state),
         canCache: selectors.canCacheDataSourceSelector(state),
         options: (dialogState as any).options as IDataAccessComponentOptions,
     };
@@ -57,8 +61,8 @@ class OpenDatasetDialog extends React.Component<IOpenDatasetDialogProps & Dispat
 
     static mapPropsToState(nextProps: IOpenDatasetDialogProps): IOpenDatasetDialogState {
         let options: IDataAccessComponentOptions = nextProps.options
-                      || DataAccessComponent.defaultOptions(isLocalDataStore(nextProps.dataStore),
-                                                            nextProps.temporalCoverage);
+                                                   || DataAccessComponent.defaultOptions(isLocalDataStore(nextProps.dataStore),
+                                                                                         nextProps.temporalCoverage);
         const isCacheDataSourceSelected = nextProps.canCache && options.isCacheDataSourceSelected;
         options = DataAccessComponent.ensureDateRangeIsValidated(options, nextProps.temporalCoverage);
         options = {...options, isCacheDataSourceSelected}
@@ -149,12 +153,13 @@ class OpenDatasetDialog extends React.Component<IOpenDatasetDialogProps & Dispat
                 dataSource={this.props.dataSource}
                 isLocalDataSource={this.isLocalDataStore}
                 temporalCoverage={this.props.temporalCoverage}
+                canConstrainTime={this.props.canConstrainTime}
+                canConstrainRegion={this.props.canConstrainRegion}
+                canConstrainVariables={this.props.canConstrainVariables}
                 canCache={this.props.canCache}
-                canMap={this.props.canMap}
             />
         );
     }
-
 }
 
 export default connect(mapStateToProps)(OpenDatasetDialog);

--- a/src/renderer/reducers.ts
+++ b/src/renderer/reducers.ts
@@ -46,6 +46,7 @@ import {
 } from './state';
 import {
     AUTO_LAYER_ID,
+    computeDataSourceCapabilities,
     getFigureViewTitle,
     getPlacemarkTitleAndIndex,
     isImageLayer,
@@ -120,7 +121,16 @@ const dataReducer = (state: DataState = INITIAL_DATA_STATE, action: Action): Dat
                     throw Error('illegal data source ID: ' + dataSourceId);
                 }
                 const oldDataSource = newDataSources[dataSourceIndex];
-                newDataSources[dataSourceIndex] = {...oldDataSource, metaInfo, metaInfoStatus};
+                let capabilities = oldDataSource.capabilities;
+                if (!capabilities) {
+                    capabilities = computeDataSourceCapabilities(metaInfo);
+                }
+                newDataSources[dataSourceIndex] = {
+                    ...oldDataSource,
+                    metaInfo,
+                    metaInfoStatus,
+                    capabilities,
+                };
                 return newDataSources;
             });
         }

--- a/src/renderer/selectors.ts
+++ b/src/renderer/selectors.ts
@@ -3,11 +3,14 @@ import * as Cesium from 'cesium';
 
 import { requireElectron } from './electron';
 import {
+    canOpenDataSource,
     canCacheDataSource,
     canMapDataSource,
-    canOpenDataSource, canConstrainDataSourceRegion, canConstrainDataSourceTime,
+    canConstrainDataSourceRegion,
+    canConstrainDataSourceTime,
+    canConstrainDataSourceVariables,
     DEFAULT_BASE_MAP,
-    DEFAULT_BASE_MAP_ID, canConstrainDataSourceVariables
+    DEFAULT_BASE_MAP_ID,
 } from './state-util';
 import {
     BaseMapState,

--- a/src/renderer/selectors.ts
+++ b/src/renderer/selectors.ts
@@ -471,6 +471,31 @@ export const canMapDataSourceSelector = createSelector<State, boolean, DataSourc
         return selectedDataSource ? canMapDataSource(selectedDataSource) : false;
     }
 );
+export const canConstrainDataSourceTimeSelector = createSelector<State, boolean, DataSourceState | null>(
+    selectedDataSourceSelector,
+    (selectedDataSource: DataSourceState | null): boolean => {
+        // TODO (forman): implement me! (check time data vars/dims)
+        return true;
+    }
+);
+export const canConstrainDataSourceRegionSelector = createSelector<State, boolean, DataSourceState | null>(
+    selectedDataSourceSelector,
+    (selectedDataSource: DataSourceState | null): boolean => {
+        // TODO (forman): implement me! (check spatial data vars/dims)
+        return selectedDataSource ? canMapDataSource(selectedDataSource) : false;
+    }
+);
+export const canConstrainDataSourceVariablesSelector = createSelector<State, boolean, DataSourceState | null>(
+    selectedDataSourceSelector,
+    (selectedDataSource: DataSourceState | null): boolean => {
+        if (selectedDataSource
+            && selectedDataSource.metaInfo
+            && selectedDataSource.metaInfo.variables) {
+            return selectedDataSource.metaInfo.variables.length > 1;
+        }
+        return false;
+    }
+);
 
 //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Workspace, resource, step, and variable selectors

--- a/src/renderer/selectors.ts
+++ b/src/renderer/selectors.ts
@@ -39,7 +39,7 @@ import {
     WorldViewDataState
 } from './state';
 import { JobStatusEnum, WebAPIClient } from './webapi';
-import { BackendConfigAPI, ColorMapsAPI, DatasetAPI, OperationAPI, WorkspaceAPI, FileSystemAPI } from './webapi/apis';
+import { BackendConfigAPI, ColorMapsAPI, DatasetAPI, OperationAPI, WorkspaceAPI, FileSystemAPI } from './webapi';
 import { PanelContainerLayout } from './components/PanelContainer';
 import {
     EXTERNAL_OBJECT_STORE,
@@ -471,29 +471,42 @@ export const canMapDataSourceSelector = createSelector<State, boolean, DataSourc
         return selectedDataSource ? canMapDataSource(selectedDataSource) : false;
     }
 );
+
 export const canConstrainDataSourceTimeSelector = createSelector<State, boolean, DataSourceState | null>(
     selectedDataSourceSelector,
     (selectedDataSource: DataSourceState | null): boolean => {
-        // TODO (forman): implement me! (check time data vars/dims)
-        return true;
+        return (selectedDataSource
+                && !!selectedDataSource.metaInfo
+                && !!selectedDataSource.metaInfo.data_vars
+                && !!selectedDataSource.metaInfo.data_vars.find(v => v.dims && v.dims.find(d => d === 'time'))
+                && !!selectedDataSource.metaInfo.coords
+                && !!selectedDataSource.metaInfo.coords.find(v => v.name === 'time'));
     }
 );
+
 export const canConstrainDataSourceRegionSelector = createSelector<State, boolean, DataSourceState | null>(
     selectedDataSourceSelector,
     (selectedDataSource: DataSourceState | null): boolean => {
-        // TODO (forman): implement me! (check spatial data vars/dims)
-        return selectedDataSource ? canMapDataSource(selectedDataSource) : false;
+        if (selectedDataSource && canMapDataSource(selectedDataSource)) {
+            return true;
+        }
+        return (selectedDataSource
+                && !!selectedDataSource.metaInfo
+                && !!selectedDataSource.metaInfo.data_vars
+                && !!selectedDataSource.metaInfo.data_vars.find(v => v.dims && v.dims.slice(v.dims.length - 2) === ['lat', 'lon'])
+                && !!selectedDataSource.metaInfo.coords
+                && !!selectedDataSource.metaInfo.coords.find(v => v.name === 'lat')
+                && !!selectedDataSource.metaInfo.coords.find(v => v.name === 'lon'));
     }
 );
+
 export const canConstrainDataSourceVariablesSelector = createSelector<State, boolean, DataSourceState | null>(
     selectedDataSourceSelector,
     (selectedDataSource: DataSourceState | null): boolean => {
-        if (selectedDataSource
-            && selectedDataSource.metaInfo
-            && selectedDataSource.metaInfo.variables) {
-            return selectedDataSource.metaInfo.variables.length > 1;
-        }
-        return false;
+        return selectedDataSource
+               && selectedDataSource.metaInfo
+               && selectedDataSource.metaInfo.data_vars
+               && selectedDataSource.metaInfo.data_vars.length > 1;
     }
 );
 

--- a/src/renderer/selectors.ts
+++ b/src/renderer/selectors.ts
@@ -5,9 +5,9 @@ import { requireElectron } from './electron';
 import {
     canCacheDataSource,
     canMapDataSource,
-    canOpenDataSource,
+    canOpenDataSource, canConstrainDataSourceRegion, canConstrainDataSourceTime,
     DEFAULT_BASE_MAP,
-    DEFAULT_BASE_MAP_ID
+    DEFAULT_BASE_MAP_ID, canConstrainDataSourceVariables
 } from './state-util';
 import {
     BaseMapState,
@@ -475,38 +475,21 @@ export const canMapDataSourceSelector = createSelector<State, boolean, DataSourc
 export const canConstrainDataSourceTimeSelector = createSelector<State, boolean, DataSourceState | null>(
     selectedDataSourceSelector,
     (selectedDataSource: DataSourceState | null): boolean => {
-        return (selectedDataSource
-                && !!selectedDataSource.metaInfo
-                && !!selectedDataSource.metaInfo.data_vars
-                && !!selectedDataSource.metaInfo.data_vars.find(v => v.dims && v.dims.find(d => d === 'time'))
-                && !!selectedDataSource.metaInfo.coords
-                && !!selectedDataSource.metaInfo.coords.find(v => v.name === 'time'));
+        return selectedDataSource && canConstrainDataSourceTime(selectedDataSource);
     }
 );
 
 export const canConstrainDataSourceRegionSelector = createSelector<State, boolean, DataSourceState | null>(
     selectedDataSourceSelector,
     (selectedDataSource: DataSourceState | null): boolean => {
-        if (selectedDataSource && canMapDataSource(selectedDataSource)) {
-            return true;
-        }
-        return (selectedDataSource
-                && !!selectedDataSource.metaInfo
-                && !!selectedDataSource.metaInfo.data_vars
-                && !!selectedDataSource.metaInfo.data_vars.find(v => v.dims && v.dims.slice(v.dims.length - 2) === ['lat', 'lon'])
-                && !!selectedDataSource.metaInfo.coords
-                && !!selectedDataSource.metaInfo.coords.find(v => v.name === 'lat')
-                && !!selectedDataSource.metaInfo.coords.find(v => v.name === 'lon'));
+        return selectedDataSource && canConstrainDataSourceRegion(selectedDataSource);
     }
 );
 
 export const canConstrainDataSourceVariablesSelector = createSelector<State, boolean, DataSourceState | null>(
     selectedDataSourceSelector,
     (selectedDataSource: DataSourceState | null): boolean => {
-        return selectedDataSource
-               && selectedDataSource.metaInfo
-               && selectedDataSource.metaInfo.data_vars
-               && selectedDataSource.metaInfo.data_vars.length > 1;
+        return selectedDataSource && canConstrainDataSourceVariables(selectedDataSource);
     }
 );
 

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -90,7 +90,11 @@ export interface DataStoreState {
     dataSources?: DataSourceState[] | null;
 }
 
-export type DataSourceCapability = "open" | "cache" | "open_time" | "open_region";
+export type DataSourceCapability =
+    "open"
+    | "write_zarr"
+    | "constrain_time"
+    | "constrain_region";
 
 
 export interface DatasetDescriptor {

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -101,7 +101,8 @@ export interface DatasetDescriptor {
     spatial_res?: number;
     time_range?: [string | null, string | null];
     time_period?: string;
-    variables?: VariableDescriptor[];
+    data_vars?: VariableDescriptor[];
+    coords?: VariableDescriptor[];
     abstract?: string;
     catalog_url?: string;
     catalogue_url?: string;
@@ -119,6 +120,7 @@ export interface VariableDescriptor {
     units?: string;
     long_name?: string;
     standard_name?: string;
+    dims?: string[];
 }
 
 // TODO: (forman) use this in the future instead of DatasetDescriptor/VariableDescriptor

--- a/src/renderer/state.ts
+++ b/src/renderer/state.ts
@@ -90,7 +90,7 @@ export interface DataStoreState {
     dataSources?: DataSourceState[] | null;
 }
 
-export type DataSourceVerificationFlags = "open" | "cache" | "map";
+export type DataSourceCapability = "open" | "cache" | "open_time" | "open_region";
 
 
 export interface DatasetDescriptor {
@@ -154,6 +154,7 @@ export interface VariableDescriptor2 {
     chunks?: number[] | null;
     attrs?: { [attr_name: string]: any } | null;
 }
+
 // }}}}}}}}}}}}
 
 
@@ -167,7 +168,7 @@ export interface DataSourceState {
     // descriptor?: DatasetDescriptor2 | GeoDataFrameDescriptor2;
     // descriptorStatus: 'init' | 'loading' | 'ok' | 'error';
     typeSpecifier?: string | null;
-    verificationFlags?: DataSourceVerificationFlags[] | null;
+    capabilities?: DataSourceCapability[] | null;
     temporalCoverage?: [string, string] | null;
 }
 

--- a/src/renderer/webapi/apis/DatasetAPI.ts
+++ b/src/renderer/webapi/apis/DatasetAPI.ts
@@ -59,7 +59,7 @@ export class DatasetAPI {
                 id: dataSource['id'],
                 title: dataSource['title'],
                 typeSpecifier: dataSource['type_specifier'] || 'dataset',
-                verificationFlags: dataSource['verification_flags'],
+                capabilities: dataSource['verification_flags'],
                 metaInfoStatus: 'init',
             };
         });


### PR DESCRIPTION
UI changes wrt https://github.com/CCI-Tools/cate/pull/1006:

Datasets availablitiy and capabilities are now derived from obtained (ODP store) and computed (Zarr store) `verification_flags` (called `capabilities` in Cate App):

- "open"  - dataset can be opened
- "constrain_time" - dataset can be opened and time can be constrained
- "constrain_region" - dataset can be opened and region (bbox) can be constrained
- "write_zarr" - dataset can be opened and cached
