### PR TITLE
Dzelge xxx ghactions update versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,9 +93,9 @@ jobs:
       - name: cat-result
         working-directory: ./k8s/cate/helm
         run: |
-          head -n 100 values-dev.yaml
-          head -n 100 values-stage.yaml
-          head -n 100 values-prod.yaml
+          head -n 16 values-dev.yaml
+          head -n 16 values-stage.yaml
+          head -n 16 values-prod.yaml
       - name: set-version-tag-cate
         uses: bc-org/gha-update-application-version-tags@main
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,9 +93,9 @@ jobs:
       - name: cat-result
         working-directory: ./k8s/cate/helm
         run: |
-          head values-dev.yaml
-          head values-stage.yaml
-          head values-prod.yaml
+          head -n 100 values-dev.yaml
+          head -n 100 values-stage.yaml
+          head -n 100 values-prod.yaml
       - name: set-version-tag-cate
         uses: bc-org/gha-update-application-version-tags@main
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,3 +40,86 @@ jobs:
           registry: quay.io
           username: ${{ secrets.QUAY_DOCKER_REPO_USERNAME }}
           password: ${{ secrets.QUAY_DOCKER_REPO_PASSWORD }}
+  update-version-cate-app:
+    env:
+      PUSH: 1
+    runs-on: ubuntu-latest
+    needs: build-docker-image
+    name: update-version-cate-app
+    steps:
+      - name: git-checkout
+        uses: actions/checkout@v2
+      - uses: actions/checkout@v2
+        with:
+          repository: bc-org/k8s-configs
+          token: ${{ secrets.API_TOKEN_GITHUB }}
+          path: k8s
+      - name: get-release-tag
+        id: release
+        run: echo ::set-output name=tag::${GITHUB_REF#refs/*/}
+      - name: deployment-phase
+        id: deployment-phase
+        uses: bc-org/gha-determine-phase@v0.1
+        with:
+          event_name: ${{ github.event_name }}
+          tag: ${{ steps.release.outputs.tag }}
+      - name: get-hash
+        id: get-hash
+        run: |
+          HASH=$(skopeo inspect docker://${{ env.REG_NAME }}/${{ env.ORG_NAME }}/${{ env.APP_NAME }}:${{ steps.release.outputs.tag }} | jq '.Digest')
+          if [[ "$HASH" == *"sha256"* ]]; then
+            echo ::set-output name=hash::$HASH
+          else
+            echo "No hash present. Using none as hash. This will use the version tag instead for the deployment."
+            echo ::set-output name=hash::none
+          fi
+      - name: info
+        run: |
+          echo "Event: ${{ github.event_name }}"
+          echo "Deployment Stage: ${{ steps.deployment-phase.outputs.phase }}"
+
+          echo "Release Tag: ${{ steps.release.outputs.tag }}"
+          echo "Deployment Release Tag: ${{ steps.deployment-phase.outputs.tag }}"
+          echo "Deployment Digest: ${{ steps.get-hash.outputs.hash }}"
+      - name: set-version-tag-cate
+        uses: bc-org/update-application-version-tags@main
+        with:
+          app: xcube-hub
+          phase: ${{ steps.deployment-phase.outputs.phase }}
+          delimiter: ' '
+          tag: ${{ steps.deployment-phase.outputs.tag }}
+          hash: ${{ steps.get-hash.outputs.hash }}
+          working-directory: ./k8s/cate/helm
+      - name: cat-result
+        working-directory: ./k8s/cate/helm
+        run: |
+          head values-dev.yaml
+          head values-stage.yaml
+          head values-prod.yaml
+      - name: set-version-tag-cate
+        uses: bc-org/gha-update-application-version-tags@main
+        with:
+          app: xcube-hub
+          phase: ${{ steps.deployment-phase.outputs.phase }}
+          delimiter: ' '
+          tag: ${{ steps.deployment-phase.outputs.tag }}
+          hash: ${{ steps.get-hash.outputs.hash }}
+          working-directory: ./k8s/xcube-gen/helm
+      - name: cat-result
+        working-directory: ./k8s/xcube-gen/helm
+        run: |
+          head values-dev.yaml
+          head values-stage.yaml
+          head values-prod.yaml
+      - name: Pushes to another repository
+        if: ${{ steps.deployment-phase.outputs.phase != 'ignore' }}
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.API_TOKEN_GITHUB }}
+        with:
+          source-directory: 'k8s'
+          destination-github-username: 'bc-org'
+          destination-repository-name: 'k8s-configs'
+          user-email: bcdev@brockmann-consult.de
+          target-branch: main
+          commit-message: ${{ github.event.release }}. Set version to ${{ steps.release.outputs.tag }}


### PR DESCRIPTION
When accepting this PR the GH workflow should update the version in the respective values files in the k8s-configs repository. That will trigger automatic deployments for the cate dev and stage environment.

The following rules apply for deployment:

- push to master auto-updates dev deployment (docker image tag will be 'latest')
- dev release auto-updates dev and stage  deployment
- prod release auto-updates dev and stage deployment. Prod itself needs manual deployment