### PR TITLE
Fix workspace Issues

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,9 @@
   unintentionally closed WebSocket connections:
   - Allow toasts to stay longer for such errors (2 minutes).
   - Provide more details on the console. 
+
+* No longer attempt to load in scratch workspaces at startup
+  (avoid error message).
   
 ### Changes 3.1.0
 

--- a/src/renderer/actions.ts
+++ b/src/renderer/actions.ts
@@ -1248,6 +1248,7 @@ export function newWorkspace(workspacePath: string | null): ThunkAction {
             } else {
                 dispatch(setSelectedWorkspaceResourceName(null));
             }
+            dispatch(savePreferences());
         }
 
         function planB(jobFailure: JobFailure) {
@@ -1285,6 +1286,7 @@ export function openWorkspace(workspacePath?: string | null): ThunkAction {
             } else {
                 dispatch(setSelectedWorkspaceResourceName(null));
             }
+            dispatch(savePreferences());
         }
 
         function planB() {

--- a/src/renderer/actions.ts
+++ b/src/renderer/actions.ts
@@ -1702,7 +1702,11 @@ export function setCurrentWorkspace(workspace: WorkspaceState): ThunkAction {
         dispatch(setCurrentWorkspaceImpl(workspace));
         const lastWorkspacePath = workspace.baseDir;
         if (getState().session.lastWorkspacePath !== lastWorkspacePath) {
-            dispatch(updateSessionState({lastWorkspacePath}));
+            if (workspace.isScratch) {
+                dispatch(updateSessionState({'lastWorkspacePath': null}));
+            } else {
+                dispatch(updateSessionState({lastWorkspacePath}));
+            }
         }
     }
 }


### PR DESCRIPTION
With this PR, only non-scratch workspaces are saved in sessions as last workspace. If the current workspace is scratch, it is null in the session.
Also, every time a workspace is created or opened, it is saved as the last used workspace.