### PR TITLE
Ensure data sources are not loaded before saved preferences have been loaded

### DIFF
--- a/src/renderer/actions.ts
+++ b/src/renderer/actions.ts
@@ -360,7 +360,6 @@ export function connectWebAPIService(webAPIServiceURL: string): ThunkAction {
             dispatch(loadBackendConfig());
             dispatch(loadColorMaps());
             dispatch(loadPreferences());
-            dispatch(loadDataStores());
             dispatch(loadOperations());
             keepAliveTimer = setInterval(keepAlive, keepAliveSeconds * 1000);
         };
@@ -490,6 +489,7 @@ export function loadPreferences(): ThunkAction {
             dispatch(loadInitialWorkspace(
                 getState().session.reopenLastWorkspace,
                 getState().session.lastWorkspacePath));
+            dispatch(loadDataStores());
         }
 
         function planB(jobFailure: JobFailure) {

--- a/src/renderer/actions.ts
+++ b/src/renderer/actions.ts
@@ -486,10 +486,10 @@ export function loadPreferences(): ThunkAction {
 
         function action(session: Partial<SessionState>) {
             dispatch(updateSessionState(session));
+            dispatch(loadDataStores());
             dispatch(loadInitialWorkspace(
                 getState().session.reopenLastWorkspace,
                 getState().session.lastWorkspacePath));
-            dispatch(loadDataStores());
         }
 
         function planB(jobFailure: JobFailure) {


### PR DESCRIPTION
Hopefully solves #56. Unfortunately, as I could not reproduce the problem with the "Loading data sources ..." panel locally, I cannot tell for sure before we try this on our development cluster.