### PR TITLE
Open in browser and kill server

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate-app",
-  "version": "4.0.0-dev.2",
+  "version": "4.0.0-dev.3",
   "private": true,
   "homepage": ".",
   "dependencies": {

--- a/src/renderer/actions.ts
+++ b/src/renderer/actions.ts
@@ -171,6 +171,8 @@ export function setWebAPIServiceInfo(webAPIServiceInfo: WebAPIServiceInfo): Acti
 
 export function connectWebAPIService(webAPIServiceURL: string): ThunkAction {
     return async (dispatch: Dispatch, getState: GetState) => {
+        console.debug("webAPIServiceURL =", webAPIServiceURL);
+
         dispatch(setWebAPIServiceURL(webAPIServiceURL));
         dispatch(setWebAPIStatus('connecting'));
 

--- a/src/renderer/actions.ts
+++ b/src/renderer/actions.ts
@@ -2176,6 +2176,17 @@ export function hidePreferencesDialog() {
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// (User) Preferences actions
+
+export function showShutdownDialog() {
+    return showDialog('shutdownDialog');
+}
+
+export function hideShutdownDialog() {
+    return hideDialog('shutdownDialog');
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 // Desktop-PWA installation support actions
 
 export const SHOW_PWA_INSTALL_PROMOTION = 'SHOW_PWA_INSTALL_PROMOTION';

--- a/src/renderer/containers/AppBar.tsx
+++ b/src/renderer/containers/AppBar.tsx
@@ -39,6 +39,14 @@ const _AppBar: React.FC<IAppBarProps & IDispatch> = (
     }
 ) => {
 
+    const handleOpenInBrowser = () => {
+        window.open(window.location.href, "_blank");
+    };
+
+    const handleShutdownServer = () => {
+        dispatch(actions.showShutdownDialog());
+    };
+
     const handlePreferencesClick = () => {
         dispatch(actions.showPreferencesDialog());
     };
@@ -60,6 +68,16 @@ const _AppBar: React.FC<IAppBarProps & IDispatch> = (
                     <Button className="bp3-minimal" rightIcon={'caret-down'}>Help</Button>
                 </Popover>
                 <NavbarDivider/>
+                <Button
+                    className="bp3-minimal"
+                    icon='share'
+                    onClick={handleOpenInBrowser}
+                />
+                <Button
+                    className="bp3-minimal"
+                    icon='delete'
+                    onClick={handleShutdownServer}
+                />
                 <Button
                     className="bp3-minimal"
                     icon='cog'

--- a/src/renderer/containers/AppBar.tsx
+++ b/src/renderer/containers/AppBar.tsx
@@ -77,7 +77,7 @@ const _AppBar: React.FC<IAppBarProps & IDispatch> = (
                 }
                 <Button
                     className="bp3-minimal"
-                    icon='delete'
+                    icon='offline'
                     onClick={handleShutdownServer}
                 />
                 <Button

--- a/src/renderer/containers/AppBar.tsx
+++ b/src/renderer/containers/AppBar.tsx
@@ -68,11 +68,13 @@ const _AppBar: React.FC<IAppBarProps & IDispatch> = (
                     <Button className="bp3-minimal" rightIcon={'caret-down'}>Help</Button>
                 </Popover>
                 <NavbarDivider/>
-                <Button
-                    className="bp3-minimal"
-                    icon='share'
-                    onClick={handleOpenInBrowser}
-                />
+                {isRunningInIFrame() &&
+                    <Button
+                        className="bp3-minimal"
+                        icon='share'
+                        onClick={handleOpenInBrowser}
+                    />
+                }
                 <Button
                     className="bp3-minimal"
                     icon='delete'
@@ -92,3 +94,11 @@ const AppBar = connect(mapStateToProps)(_AppBar);
 export default AppBar;
 
 
+// https://stackoverflow.com/questions/326069/how-to-identify-if-a-webpage-is-being-loaded-inside-an-iframe-or-directly-into-t
+function isRunningInIFrame(): boolean {
+    try {
+        return window.self !== window.top;
+    } catch (e) {
+        return true;
+    }
+}

--- a/src/renderer/containers/AppMainPage.tsx
+++ b/src/renderer/containers/AppMainPage.tsx
@@ -5,12 +5,13 @@ import { useMatomo } from '@datapunt/matomo-tracker-react'
 
 import GdprBanner from './GdprBanner';
 import { isElectron } from '../electron';
-import { FileSystemAPI } from '../webapi';
+import { FileSystemAPI, ServiceShutdownAPI } from '../webapi';
 import AppBar from './AppBar';
 import ChooseWorkspaceDialog, { DELETE_WORKSPACE_DIALOG_ID, OPEN_WORKSPACE_DIALOG_ID } from './ChooseWorkspaceDialog';
 import GlobeView from './GlobeView'
 import FigureView from './FigureView';
-import ServiceAutoCloseDialog from './ServiceAutoCloseDialog';
+import ServiceAutoShutdownDialog from './ServiceAutoShutdownDialog';
+import ServiceShutdownDialog from './ServiceShutdownDialog';
 import TableView from './TableView';
 import DataSourcesPanel from './DataSourcesPanel';
 import OperationsPanel from './OperationsPanel';
@@ -170,7 +171,8 @@ const _AppMainPage: React.FC<IApplicationPageProps & IDispatch> = (
             <FileUploadDialog/>
             <FileDownloadDialog/>
             <SaveWorkspaceAsDialog/>
-            <ServiceAutoCloseDialog/>
+            <ServiceShutdownDialog/>
+            <ServiceAutoShutdownDialog/>
             <ChooseWorkspaceDialog dialogId={OPEN_WORKSPACE_DIALOG_ID}/>
             <ChooseWorkspaceDialog dialogId={DELETE_WORKSPACE_DIALOG_ID}/>
             <OperationStepDialog id={NEW_CTX_OPERATION_STEP_DIALOG_ID}/>

--- a/src/renderer/containers/ServiceAutoShutdownDialog.tsx
+++ b/src/renderer/containers/ServiceAutoShutdownDialog.tsx
@@ -10,19 +10,19 @@ import { ServiceInfoAPI } from '../webapi/apis/ServiceInfoAPI';
 //
 const DIALOG_DURATION_MIN = (process.env.NODE_ENV === 'development' ? 1 : 15) * 60;
 
-interface IServiceAutoCloseDialogProps {
+interface IServiceAutoShutdownDialogProps {
     webAPIServiceInfo: WebAPIServiceInfo | null;
     webAPIServiceURL: string;
 }
 
-function mapStateToProps(state: State): IServiceAutoCloseDialogProps {
+function mapStateToProps(state: State): IServiceAutoShutdownDialogProps {
     return {
         webAPIServiceInfo: selectors.webAPIServiceInfoSelector(state),
         webAPIServiceURL: selectors.webAPIServiceURLSelector(state),
     };
 }
 
-const ServiceAutoCloseDialog: React.FC<IServiceAutoCloseDialogProps & DispatchProp<State>> = (
+const ServiceAutoShutdownDialog: React.FC<IServiceAutoShutdownDialogProps & DispatchProp<State>> = (
     {
         webAPIServiceInfo,
         webAPIServiceURL,
@@ -100,7 +100,7 @@ const ServiceAutoCloseDialog: React.FC<IServiceAutoCloseDialogProps & DispatchPr
     );
 }
 
-export default connect(mapStateToProps)(ServiceAutoCloseDialog);
+export default connect(mapStateToProps)(ServiceAutoShutdownDialog);
 
 
 function formatSeconds(value: number): string {

--- a/src/renderer/containers/ServiceShutdownDialog.tsx
+++ b/src/renderer/containers/ServiceShutdownDialog.tsx
@@ -1,0 +1,83 @@
+import * as React from 'react';
+import { hideShutdownDialog } from '../actions';
+import { State } from '../state';
+import { ModalDialog } from '../components/ModalDialog';
+import { connect, DispatchProp } from 'react-redux';
+import * as selectors from '../selectors';
+import { ServiceShutdownAPI } from '../webapi';
+
+
+const DIALOG_ID = "shutdownDialog";
+
+interface IServiceShutdownDialogProps {
+    isOpen: boolean;
+    webAPIServiceURL: string;
+}
+
+function mapStateToProps(state: State): IServiceShutdownDialogProps {
+    const dialogState = selectors.dialogStateSelector(DIALOG_ID)(state);
+
+    return {
+        isOpen: dialogState.isOpen,
+        webAPIServiceURL: selectors.webAPIServiceURLSelector(state),
+    };
+}
+
+const ServiceShutdownDialog: React.FC<IServiceShutdownDialogProps & DispatchProp<State>> = (
+    {
+        isOpen,
+        webAPIServiceURL,
+        dispatch
+    }
+) => {
+    let [waiting, setWaiting] = React.useState(false);
+
+    if (!isOpen) {
+        return null;
+    }
+
+    const handleShutdown = () => {
+        // Make any harmless REST call so the
+        // server's inactivity timer is reset:
+        try {
+            setWaiting(true);
+            // noinspection JSIgnoredPromiseFromCall
+            new ServiceShutdownAPI().shutdown(webAPIServiceURL).then(() => {
+                dispatch(hideShutdownDialog());
+            });
+        } catch (error) {
+            setWaiting(false);
+        }
+    }
+
+    const handleClose = () => {
+        dispatch(hideShutdownDialog());
+    }
+
+    const renderBody = () => {
+        return (
+            <p>
+                This will shut down the Cate service.
+                Unsaved changes will be lost.
+            </p>
+        );
+    }
+
+    return (
+        <ModalDialog
+            isOpen={true}
+            title="Service Shutdown"
+            icon="offline"
+            noCancelButton={false}
+            confirmTitle="Shutdown"
+            confirmIconName="offline"
+            canConfirm={() => !waiting}
+            onConfirm={handleShutdown}
+            onCancel={handleClose}
+            renderBody={renderBody}
+        />
+    );
+}
+
+export default connect(mapStateToProps)(ServiceShutdownDialog);
+

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -13,6 +13,23 @@ import { connectWebAPIService } from './actions';
 import { DEFAULT_SERVICE_URL } from './initial-state';
 
 
+function getServiceUrl() {
+    let serviceUrl: string = DEFAULT_SERVICE_URL;
+    const search = new URLSearchParams(window.location.search);
+    if (search.has('serviceUrl')) {
+        serviceUrl = search.get('serviceUrl');
+    } else {
+        const origin = window.location.origin;
+        const path = window.location.pathname;
+        if (path.endsWith('/app')) {
+            serviceUrl = origin + path.substring(0, path.length - 4);
+        } else if (path.endsWith('/app/')) {
+            serviceUrl = origin + path.substring(0, path.length - 5);
+        }
+    }
+    return serviceUrl;
+}
+
 export function main() {
     const middlewares: Middleware[] = [thunkMiddleware];
 
@@ -36,13 +53,7 @@ export function main() {
 
     const middleware = applyMiddleware(...middlewares);
     const store = createStore(stateReducer, middleware) as Store<State>;
-
-    const search = new URLSearchParams(window.location.search);
-    let serviceUrl = DEFAULT_SERVICE_URL;
-    if (search.has("serviceUrl")) {
-        serviceUrl = search.get("serviceUrl");
-    }
-    store.dispatch(connectWebAPIService(serviceUrl) as any);
+    store.dispatch(connectWebAPIService(getServiceUrl()) as any);
 
     ReactDOM.render(
         (

--- a/src/renderer/webapi/apis/ServiceShutdownAPI.ts
+++ b/src/renderer/webapi/apis/ServiceShutdownAPI.ts
@@ -1,0 +1,10 @@
+
+export class ServiceShutdownAPI {
+    shutdown(serviceURL: string): Promise<null> {
+        const url = new URL(serviceURL + "/kill");
+        return fetch(serviceURL + "/exit")
+            .then((response: Response) => {
+                return null;
+            });
+    }
+}

--- a/src/renderer/webapi/apis/index.ts
+++ b/src/renderer/webapi/apis/index.ts
@@ -4,3 +4,4 @@ export { WorkspaceAPI } from './WorkspaceAPI';
 export { BackendConfigAPI } from './BackendConfigAPI';
 export { ColorMapsAPI } from './ColorMapsAPI';
 export { FileSystemAPI } from './FileSystemAPI';
+export { ServiceShutdownAPI } from './ServiceShutdownAPI';

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,5 +1,5 @@
 // IMPORTANT: Any changes of CATE_APP_VERSION must be synchronized
 // with the version field in "../package.json".
 //
-export const CATE_APP_VERSION = "4.0.0-dev.2";
+export const CATE_APP_VERSION = "4.0.0-dev.3";
 


### PR DESCRIPTION
This PR add two new features to Cate App running as widget in JL:

1. Open in browser
2. Shutdown server

They can be found in app bar as toolbar buttons.

In addition, the service URL will be detected by the pattern `"${serviceUrl}/app"` or `"${serviceUrl}/app/"`. So in such cases the service URL no longer needs to passed as query parameter `serviceUrl`.
