### PR TITLE
More UI adjustments

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,7 @@
 ### Changes 4.0.0 (in development)
 
 * Since Cate App is now designed to work inside of Jupyter Lab and standalone,
-  the user login action is no longer required because users already log into 
+  The user login action is no longer required because users already log into 
   JupyterLab. Therefore, all code dealing with user login and Cate service 
   provisioning in the cloud has been removed. Other changes include:
   - Added a new user action to open Cate App in a browser tab available, if

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,14 +1,20 @@
 ### Changes 4.0.0 (in development)
 
-* Now using workspace identifiers instead of base directories in resource
-  URLs of the WebAPI. This way we no longer need to URL-encode workspace
-  directories in WebAPI URLs, which did not work with
-  [jupyter-server-proxy](https://jupyter-server-proxy.readthedocs.io/).
-
 * Since Cate App is now designed to work inside of Jupyter Lab and standalone,
-  all code dealing with user login and Cate service provisioning in the 
-  cloud has been removed.
-
+  the user login action is no longer required because users already log into 
+  JupyterLab. Therefore, all code dealing with user login and Cate service 
+  provisioning in the cloud has been removed. Other changes include:
+  - Added a new user action to open Cate App in a browser tab available, if
+    Cate App is initially opened in a JupyterLab widget.
+  - Added a new user action to shut down the Cate server 
+    in order to release memory.
+  - Removed the top level **Files** menu, because file management can
+    be effectively done through JupyterLab.
+  - Removed the user action to install Cate App as a Desktop PWA.
+  - Removed proxy configuration from user preferences dialog.
+  - Rephrased filesystem info from "sandboxed / full access" to 
+    "restricted / unrestricted".
+  
 * The following changes apply to the "local" data store because the server
   now serves local files from the current working directory. This has been
   done to let Cate integrated with Jupyter Lab pick up all datasets found 
@@ -18,11 +24,12 @@
     This is a temporary change. We may reassign add/remove actions to perform
     a filtering on the local datasets.
 
-* When running Cate App as a JupyterLab widget, there is now a new action to 
-  open it in a browser tab.
+* Now using workspace identifiers instead of base directories in resource
+  URLs of the WebAPI. This way we no longer need to URL-encode workspace
+  directories in WebAPI URLs, which did not work with
+  [jupyter-server-proxy](https://jupyter-server-proxy.readthedocs.io/).
 
-* Users can now shut down the Cate service in order to release memory.
-
+    
 ### Changes 3.1.4
 
 * Updated to new keycloak version

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cate-app",
-  "version": "4.0.0-dev.4",
+  "version": "4.0.0-dev.5",
   "private": true,
   "homepage": ".",
   "dependencies": {

--- a/src/renderer/actions.ts
+++ b/src/renderer/actions.ts
@@ -2188,41 +2188,6 @@ export function hideShutdownDialog() {
     return hideDialog('shutdownDialog');
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-// Desktop-PWA installation support actions
-
-export const SHOW_PWA_INSTALL_PROMOTION = 'SHOW_PWA_INSTALL_PROMOTION';
-export const HIDE_PWA_INSTALL_PROMOTION = 'HIDE_PWA_INSTALL_PROMOTION';
-export const UPDATE_PWA_DISPLAY_MODE = 'UPDATE_PWA_DISPLAY_MODE';
-
-let _deferredPwaInstallPrompt: any = null;
-
-export function showPwaInstallPromotion(deferredPrompt: any): Action {
-    // Prevent the mini info bar from appearing on mobile
-    _deferredPwaInstallPrompt = deferredPrompt;
-    _deferredPwaInstallPrompt.preventDefault();
-    return {type: SHOW_PWA_INSTALL_PROMOTION};
-}
-
-function hidePwaInstallPromotion(): Action {
-    return {type: HIDE_PWA_INSTALL_PROMOTION};
-}
-
-export const showPwaInstallPrompt = (): ThunkAction => (dispatch) => {
-    // Hide the app provided install promotion
-    dispatch(hidePwaInstallPromotion());
-    // Show the install prompt
-    _deferredPwaInstallPrompt.prompt();
-    // Wait for the user to respond to the prompt
-    _deferredPwaInstallPrompt.userChoice.then((choiceResult: any) => {
-        if (choiceResult.outcome === 'accepted') {
-            console.debug('User accepted the install prompt');
-        } else {
-            console.debug('User dismissed the install prompt');
-        }
-    });
-}
-
 /////////////////////////////////////////////////////////////////////////////////////
 // EU GDPR actions
 

--- a/src/renderer/containers/AppBar.tsx
+++ b/src/renderer/containers/AppBar.tsx
@@ -13,7 +13,7 @@ import * as actions from '../actions';
 import { State } from '../state';
 import cateIcon from '../resources/cate-icon-128.png';
 import WorkspacesMenu from './WorkspacesMenu';
-import FilesMenu from './FilesMenu';
+// import FilesMenu from './FilesMenu';
 import HelpMenu from './HelpMenu';
 
 
@@ -61,9 +61,9 @@ const _AppBar: React.FC<IAppBarProps & IDispatch> = (
                 <Popover content={<WorkspacesMenu/>} position={PopoverPosition.BOTTOM}>
                     <Button className="bp3-minimal" rightIcon={'caret-down'}>Workspaces</Button>
                 </Popover>
-                <Popover content={<FilesMenu/>} position={PopoverPosition.BOTTOM}>
-                    <Button className="bp3-minimal" rightIcon={'caret-down'}>Files</Button>
-                </Popover>
+                {/*<Popover content={<FilesMenu/>} position={PopoverPosition.BOTTOM}>*/}
+                {/*    <Button className="bp3-minimal" rightIcon={'caret-down'}>Files</Button>*/}
+                {/*</Popover>*/}
                 <Popover content={<HelpMenu/>} position={PopoverPosition.BOTTOM}>
                     <Button className="bp3-minimal" rightIcon={'caret-down'}>Help</Button>
                 </Popover>

--- a/src/renderer/containers/AppMainPage.tsx
+++ b/src/renderer/containers/AppMainPage.tsx
@@ -5,7 +5,7 @@ import { useMatomo } from '@datapunt/matomo-tracker-react'
 
 import GdprBanner from './GdprBanner';
 import { isElectron } from '../electron';
-import { FileSystemAPI, ServiceShutdownAPI } from '../webapi';
+import { FileSystemAPI } from '../webapi';
 import AppBar from './AppBar';
 import ChooseWorkspaceDialog, { DELETE_WORKSPACE_DIALOG_ID, OPEN_WORKSPACE_DIALOG_ID } from './ChooseWorkspaceDialog';
 import GlobeView from './GlobeView'

--- a/src/renderer/containers/PreferencesDialog.tsx
+++ b/src/renderer/containers/PreferencesDialog.tsx
@@ -122,7 +122,6 @@ class PreferencesDialog extends React.Component<IPreferencesDialogProps & Dispat
             <Tabs id="preferences">
                 <Tab id="g" title="General" panel={this.renderGeneralPanel()}/>
                 <Tab id="dm" title="Data Management" panel={this.renderDataManagementPanel()}/>
-                <Tab id="pc" title="Proxy Configuration" panel={this.renderProxyConfigurationPanel()}/>
                 <Tab id="a" title="System" panel={this.renderSystemPanel()}/>
             </Tabs>
         );
@@ -148,14 +147,6 @@ class PreferencesDialog extends React.Component<IPreferencesDialogProps & Dispat
                 {!userRootMode && this.renderDataStoresPath()}
                 {!userRootMode && this.renderCacheWorkspaceImagery()}
                 {this.renderResourceNamePrefix()}
-            </div>
-        );
-    }
-
-    private renderProxyConfigurationPanel() {
-        return (
-            <div style={{width: '100%', marginTop: '1em'}}>
-                {this.renderProxyUrlInput()}
             </div>
         );
     }
@@ -220,9 +211,9 @@ class PreferencesDialog extends React.Component<IPreferencesDialogProps & Dispat
                     </ControlGroup>
                 )}
                 <ControlGroup style={SYSTEM_CONTROL_GROUP_STYLE}>
-                    <span style={SYSTEM_LABEL_STYLE}>File access mode:</span>
+                    <span style={SYSTEM_LABEL_STYLE}>Filesystem access:</span>
                     <span style={SYSTEM_ITEM_STYLE}>
-                        {this.props.serviceInfo.userRootMode ? 'sandboxed file system' : 'full access to file system'}
+                        {this.props.serviceInfo.userRootMode ? 'restricted' : 'unrestricted'}
                     </span>
                 </ControlGroup>
             </div>
@@ -290,23 +281,6 @@ class PreferencesDialog extends React.Component<IPreferencesDialogProps & Dispat
             'resourceNamePattern',
             true,
             'Default resource name pattern'
-        );
-    }
-
-    private renderProxyUrlInput() {
-        const initialValue = this.getStateValue('proxyUrl', true);
-        const onChange = this.getChangeHandler('proxyUrl', true);
-        return (
-            <ControlGroup style={{width: '100%', marginBottom: '1em', display: 'flex', alignItems: 'center'}}>
-                <span style={{flexGrow: 0.8}}>Proxy URL:</span>
-                <TextField className="bp3-input bp3-fill"
-                           style={{flexGrow: 0.2}}
-                           value={initialValue}
-                           onChange={onChange}
-                           placeholder={'http://user:password@host:port'}
-                           nullable={true}
-                />
-            </ControlGroup>
         );
     }
 

--- a/src/renderer/webapi/apis/ServiceShutdownAPI.ts
+++ b/src/renderer/webapi/apis/ServiceShutdownAPI.ts
@@ -1,10 +1,7 @@
 
 export class ServiceShutdownAPI {
     shutdown(serviceURL: string): Promise<null> {
-        const url = new URL(serviceURL + "/kill");
         return fetch(serviceURL + "/exit")
-            .then((response: Response) => {
-                return null;
-            });
+            .then(() => null);
     }
 }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,5 +1,5 @@
 // IMPORTANT: Any changes of CATE_APP_VERSION must be synchronized
 // with the version field in "../package.json".
 //
-export const CATE_APP_VERSION = "4.0.0-dev.3";
+export const CATE_APP_VERSION = "4.0.0-dev.5";
 


### PR DESCRIPTION
In this PR:

  - Removed the top level **Files** menu, because file management can
    be effectively done through JupyterLab.
  - Removed the user action to install Cate App as a Desktop PWA.
  - Removed proxy configuration from user preferences dialog.
  - Rephrased filesystem info from "sandboxed / full access" to 
    "restricted / unrestricted".